### PR TITLE
라우터 구조를 추가합니다.

### DIFF
--- a/strawberry/src/App.tsx
+++ b/strawberry/src/App.tsx
@@ -1,10 +1,14 @@
-import { GlobalContextProvider } from "./modules/core/contexts/globalContext";
+import { GlobalContextProvider } from "./core/contexts/globalContext";
+import { RouterProvider } from "react-router-dom";
+import router from "./router/router";
 
 function App() {
   return (
-    <GlobalContextProvider>
-      <></>
-    </GlobalContextProvider>
+    <>
+      <GlobalContextProvider>
+        <RouterProvider router={router}></RouterProvider>
+      </GlobalContextProvider>
+    </>
   );
 }
 

--- a/strawberry/src/layout/DefaultLayout.tsx
+++ b/strawberry/src/layout/DefaultLayout.tsx
@@ -1,16 +1,20 @@
+import { ReactNode } from "react";
 import Header from "./components/header";
 import Footer from "./components/footer";
-import { Outlet } from "react-router-dom";
 import styled from "styled-components";
 
-function DefaultLayout() {
+interface DefaultLayoutProps {
+  children?: ReactNode;
+}
+
+function DefaultLayout({ children }: DefaultLayoutProps) {
   return (
     <>
       <PageWrapper>
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        <Outlet />
+        {children}
         <FooterWrapper>
           <Footer />
         </FooterWrapper>

--- a/strawberry/src/layout/HeaderLayout.tsx
+++ b/strawberry/src/layout/HeaderLayout.tsx
@@ -1,15 +1,19 @@
+import { ReactNode } from "react";
 import Header from "./components/header";
-import { Outlet } from "react-router-dom";
 import styled from "styled-components";
 
-function HeaderLayout() {
+interface HeaderLayoutProps {
+  children?: ReactNode;
+}
+
+function HeaderLayout({ children }: HeaderLayoutProps) {
   return (
     <>
       <PageWrapper>
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        <Outlet />
+        {children}
       </PageWrapper>
     </>
   );

--- a/strawberry/src/router/ProtectedRoute.tsx
+++ b/strawberry/src/router/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from "react-router-dom";
+
+function ProtectedRoute() {
+  // 로그인 하지 않으면 navigate
+
+  return <Outlet />;
+}
+
+export default ProtectedRoute;

--- a/strawberry/src/router/PublicRoute.tsx
+++ b/strawberry/src/router/PublicRoute.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from "react-router-dom";
+
+function PublicRoute() {
+  // 로그인한 경우 navigate하는 코드 추가
+
+  return <Outlet />;
+}
+
+export default PublicRoute;

--- a/strawberry/src/router/router.tsx
+++ b/strawberry/src/router/router.tsx
@@ -1,0 +1,66 @@
+import { createBrowserRouter } from "react-router-dom";
+import DefaultLayout from "../layout/DefaultLayout";
+import HeaderLayout from "../layout/HeaderLayout";
+import PublicRoute from "./PublicRoute";
+import ProtectedRoute from "./ProtectedRoute";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <DefaultLayout />,
+    children: [
+      {
+        path: "login",
+        element: <PublicRoute>{/* <LoginPage /> */}</PublicRoute>,
+      },
+      {
+        path: "",
+        element: <>{/* <LandingPage /> */}</>,
+      },
+      {
+        path: "introduce",
+        element: <>{/* <NewCarPage /> */}</>,
+      },
+      {
+        path: "expectation",
+        element: <>{/* <ExpectationPage />, */}</>,
+      },
+      {
+        path: "quiz",
+        element: <>{/* <QuizLandingPage /> */}</>,
+      },
+      {
+        path: "drawing",
+        element: <>{/* <DrawingLandingPage /> */}</>,
+      },
+    ],
+  },
+  {
+    path: "/",
+    element: (
+      <HeaderLayout>
+        <ProtectedRoute />
+      </HeaderLayout>
+    ),
+    children: [
+      {
+        path: "quiz/play",
+        element: <>{/* <QuizPlayPage /> */}</>,
+      },
+      {
+        path: "drawing/play",
+        element: <>{/* <DrawingPlayPage /> */}</>,
+      },
+      {
+        path: "drawing/result",
+        element: <>{/* <DrawingResultPage /> */}</>,
+      },
+    ],
+  },
+  {
+    path: "auth/:sns/callback",
+    element: <PublicRoute>{/* <LoginRedirectPage /> */}</PublicRoute>,
+  },
+]);
+
+export default router;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#20-implement-router

### 💡 작업동기
- path별로 page 할당을 위한 라우터 설정을 추가하여 App에 provider로 반영

### 🔑 주요 변경사항
- 라우터 파일에 path와 element 추가
- App 컴포넌트에 router provider 추가
- 레이아웃에 outlet 대신 children으로 대체(레이아웃 밑 페이지를 위한 요소, es-lint에서 children을 권장)
- 권한 여부 확인을 위한 Protected, Public route추가
- dummy file 제거

### 관련 이슈
- closed: #20 
