### PR TITLE
이벤트 버튼을 구현합니다.

### DIFF
--- a/strawberry/src/assets/images/icons/Arrow_Right_L_Black.svg
+++ b/strawberry/src/assets/images/icons/Arrow_Right_L_Black.svg
@@ -1,0 +1,10 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Arrow_Right_L">
+<mask id="mask0_2465_1305" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="28" height="28">
+<rect id="Bounding box" width="28" height="28" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_2465_1305)">
+<path id="arrow_forward_ios" d="M7.27862 25.2008L5.30469 23.2175L14.4777 14.0008L5.30469 4.78411L7.27862 2.80078L18.4255 14.0008L7.27862 25.2008Z" fill="#171719"/>
+</g>
+</g>
+</svg>

--- a/strawberry/src/assets/images/icons/Arrow_Right_L_White.svg
+++ b/strawberry/src/assets/images/icons/Arrow_Right_L_White.svg
@@ -1,0 +1,10 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Arrow_Right_L">
+<mask id="mask0_2465_814" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="28" height="28">
+<rect id="Bounding box" width="28" height="28" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_2465_814)">
+<path id="arrow_forward_ios" d="M7.27862 25.2008L5.30469 23.2175L14.4777 14.0008L5.30469 4.78411L7.27862 2.80078L18.4255 14.0008L7.27862 25.2008Z" fill="white"/>
+</g>
+</g>
+</svg>

--- a/strawberry/src/core/design_system/buttons/EventButton.tsx
+++ b/strawberry/src/core/design_system/buttons/EventButton.tsx
@@ -1,0 +1,101 @@
+import styled, { css } from "styled-components";
+
+type ButtonType = "QUIZ" | "DRAWING";
+type ButtonStatus = "DEFAULT" | "DISABLED" | "EVENT_END";
+
+interface EventButtonProps {
+  type: ButtonType;
+  status: ButtonStatus;
+  content: string;
+  onClick?: () => void;
+}
+
+function Arrow({ type, status }: { type: ButtonType; status: ButtonStatus }) {
+  if (type === "DRAWING" && status === "DEFAULT") {
+    return (
+      <img
+        src="/src/assets/images/icons/Arrow_Right_L_Black.svg"
+        alt="화살표"
+        height={"28px"}
+        width={"28px"}
+      />
+    );
+  }
+  if (status !== "EVENT_END") {
+    return (
+      <img
+        src="/src/assets/images/icons/Arrow_Right_L_White.svg"
+        alt="화살표"
+        height={"28px"}
+        width={"28px"}
+      />
+    );
+  }
+}
+
+function EventButton({ type, status, content, onClick }: EventButtonProps) {
+  return (
+    <StyledButton type={type} status={status} onClick={onClick}>
+      <ContentWrapper>
+        <p>{content}</p>
+        <Arrow type={type} status={status} />
+      </ContentWrapper>
+    </StyledButton>
+  );
+}
+
+export default EventButton;
+
+const StyledButton = styled.button<{ type: ButtonType; status: ButtonStatus }>`
+  // 공통 css
+  display: inline-flex;
+  padding: 20px 80px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 50px;
+  ${({ theme }) => theme.Shadow.Strong};
+  ${({ theme }) => theme.Typography.Title3Medium};
+
+  // status css
+  ${({ type, status, theme }) => {
+    if (type === "DRAWING" && status === "DEFAULT") {
+      return css`
+        background-color: ${theme.Color.Event.drawing_default};
+        color: ${theme.Color.TextIcon.default};
+      `;
+    }
+    if (type === "DRAWING" && status === "DISABLED") {
+      return css`
+        color: ${theme.Color.TextIcon.reverse};
+        background-color: ${theme.Color.Event.drawing_disabled};
+      `;
+    }
+    if (type === "QUIZ" && status === "DEFAULT") {
+      return css`
+        background-color: ${theme.Color.Event.quiz_default};
+        color: ${theme.Color.TextIcon.reverse};
+      `;
+    }
+    if (type === "QUIZ" && status === "DISABLED") {
+      return css`
+        color: ${theme.Color.TextIcon.reverse};
+        background-color: ${theme.Color.Event.quiz_disabled};
+      `;
+    }
+    if (status === "EVENT_END") {
+      return css`
+        background-color: ${theme.Color.TextIcon.disable};
+        color: ${theme.Color.TextIcon.info};
+      `;
+    }
+  }}
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+`;

--- a/strawberry/src/core/design_system/buttons/EventButton.tsx
+++ b/strawberry/src/core/design_system/buttons/EventButton.tsx
@@ -35,7 +35,12 @@ function Arrow({ type, status }: { type: ButtonType; status: ButtonStatus }) {
 
 function EventButton({ type, status, content, onClick }: EventButtonProps) {
   return (
-    <StyledButton type={type} status={status} onClick={onClick}>
+    <StyledButton
+      type={type}
+      status={status}
+      onClick={onClick}
+      disabled={status !== "DEFAULT"}
+    >
       <ContentWrapper>
         <p>{content}</p>
         <Arrow type={type} status={status} />

--- a/strawberry/src/core/design_system/color.tsx
+++ b/strawberry/src/core/design_system/color.tsx
@@ -59,12 +59,20 @@ const Red = {
   red600: "#C82333",
 };
 
+const Event = {
+  quiz_default: "#FF8126",
+  quiz_disabled: "#FFCDA8",
+  drawing_default: "#B7CE61",
+  drawing_disabled: "#DBE7B0",
+};
+
 const Color = {
   Blue,
   Ivory,
   Common,
   Neutral,
   Red,
+  Event,
 
   Primary: {
     normal: Blue.blue500,

--- a/strawberry/src/core/design_system/reset.css
+++ b/strawberry/src/core/design_system/reset.css
@@ -65,3 +65,14 @@ table {
 	font-family: "Hyundai Sans Head KR Light";
 	src: url(../../../fonts/Hyundai\ Sans\ Head\ KR\ Light.ttf);
 }
+
+button {
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	outline: none;
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#23-implement-EventButton

### 💡 작업동기
- 이벤트 페이지 구현 작업에 필요한 공통 컴포넌트인 이벤트 버튼을 구현합니다.

### 🔑 주요 변경사항
- reset.css에 DefaultButton 속성 추가 (DefaultButton 삭제 예정)
- 이벤트 버튼을 위한 white, black right arrow svg 파일 추가
- 이벤트 버튼 background color를 위한 색상을 Color에 추가
- 이벤트 버튼 구현
- 사용 방법

EventButton({ type, status, content, onClick })

ButtonType = "QUIZ" | "DRAWING"
ButtonStatus = "DEFAULT" | "DISABLED" | "EVENT_END"
content = ${넣고 싶은 내용}
onClick = function 클릭 시 실행하고 싶은 함수


### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/052256ab-e786-40ef-9e96-68b8e6320412">

좌측 3개 퀴즈 버튼, 우측 3개 드로잉 버튼 / 차례로 default, disabled, event_end

### 관련 이슈
closed: #23 
