### PR TITLE
퀴즈 이벤트 페이지의 CardInput을 구현합니다.

### DIFF
--- a/strawberry/src/core/design_system/color.tsx
+++ b/strawberry/src/core/design_system/color.tsx
@@ -26,6 +26,7 @@ const Ivory = {
 
 const Common = {
   black: "#000000",
+  white: "#FFFFFF",
 };
 
 const Neutral = {

--- a/strawberry/src/pages/quiz/components/CardInput.tsx
+++ b/strawberry/src/pages/quiz/components/CardInput.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useRef, useEffect } from "react";
+import styled from "styled-components";
+
+const CardInput = ({
+  length,
+  placeholder,
+}: {
+  length: number;
+  placeholder: string;
+}) => {
+  const [content, setContent] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    if (value.length <= length) {
+      setContent(value);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      event.preventDefault();
+    }
+  };
+
+  const handleClick = () => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.setSelectionRange(content.length, content.length);
+    }
+  };
+
+  return (
+    <Container onClick={handleClick} length={length}>
+      <HiddenInput
+        ref={inputRef}
+        type="text"
+        value={content}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        maxLength={length}
+      />
+      <VisibleContent>
+        {Array.from({ length }).map((_, index) => (
+          <CharacterBox
+            key={index}
+            onClick={(e) => {
+              e.stopPropagation();
+              inputRef.current?.focus();
+              inputRef.current?.setSelectionRange(
+                content.length,
+                content.length,
+              );
+            }}
+          >
+            <Character isFilled={Boolean(content[index])}>
+              {content[index] || placeholder[index]}
+            </Character>
+          </CharacterBox>
+        ))}
+      </VisibleContent>
+    </Container>
+  );
+};
+
+export default CardInput;
+
+// Styled Components
+const Container = styled.div<{ length: number }>`
+  width: ${({ length }) => 143 * length + 25 * (length - 1)}px;
+  height: 143px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: text;
+`;
+
+const HiddenInput = styled.input`
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  font-size: 67px;
+  letter-spacing: 101px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 2;
+`;
+
+const VisibleContent = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  font-size: ${({ theme }) => theme.Typography.Display1Medium};
+  position: relative;
+  z-index: 1;
+`;
+
+const CharacterBox = styled.div`
+  width: 130px;
+  height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 16px;
+  background-color: ${({ theme }) => theme.Color.Common.white};
+  border-radius: ${({ theme }) => theme.Border.Radius6};
+  box-sizing: border-box;
+  position: relative;
+  cursor: pointer;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;
+
+const Character = styled.p<{ isFilled: boolean }>`
+  font-size: 67px;
+  color: ${({ isFilled, theme }) =>
+    isFilled ? theme.Color.TextIcon.default : theme.Color.TextIcon.assistive};
+  margin: 0;
+  line-height: 67px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  height: fit-content;
+  box-sizing: border-box;
+`;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#25-implement-CardInput

### 💡 작업동기
- 퀴즈 이벤트 진행 페이지에서 사용자의 입력을 받을 컴포넌트를 만듭니다.

### 🔑 주요 변경사항
- CardInput 구현
- color에 common.white 추가
- 더미 파일 삭제

### 🏞 스크린샷
<img width="497" alt="image" src="https://github.com/user-attachments/assets/e81c2593-dfa7-4435-8a4c-8f6ed0fa9555">


### 관련 이슈
- closed: #25 