### PR TITLE
라우터의 children을 outlet으로 변경합니다. 

### DIFF
--- a/strawberry/src/layout/DefaultLayout.tsx
+++ b/strawberry/src/layout/DefaultLayout.tsx
@@ -1,20 +1,16 @@
-import { ReactNode } from "react";
 import Header from "./components/header";
 import Footer from "./components/footer";
 import styled from "styled-components";
+import { Outlet } from "react-router-dom";
 
-interface DefaultLayoutProps {
-  children?: ReactNode;
-}
-
-function DefaultLayout({ children }: DefaultLayoutProps) {
+function DefaultLayout() {
   return (
     <>
       <PageWrapper>
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        {children}
+        <Outlet />
         <FooterWrapper>
           <Footer />
         </FooterWrapper>

--- a/strawberry/src/layout/HeaderLayout.tsx
+++ b/strawberry/src/layout/HeaderLayout.tsx
@@ -1,19 +1,15 @@
-import { ReactNode } from "react";
 import Header from "./components/header";
 import styled from "styled-components";
+import { Outlet } from "react-router-dom";
 
-interface HeaderLayoutProps {
-  children?: ReactNode;
-}
-
-function HeaderLayout({ children }: HeaderLayoutProps) {
+function HeaderLayout() {
   return (
     <>
       <PageWrapper>
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        {children}
+        <Outlet />
       </PageWrapper>
     </>
   );


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#29-replace-router-children

### 💡 작업동기
- 라우터 설정 중 레이아웃의 nested Component를 받는 과정에서 children을 사용하였더니 페이지가 렌더링 되지 않아 수정

### 🔑 주요 변경사항
- 레이아웃의 children을 Outlet으로 수정

### 관련 이슈
- closed: #29 
