### PR TITLE
레이아웃의 각 영역 크기에 대한 css를 설정합니다.

### DIFF
--- a/strawberry/src/layout/DefaultLayout.tsx
+++ b/strawberry/src/layout/DefaultLayout.tsx
@@ -10,7 +10,9 @@ function DefaultLayout() {
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        <Outlet />
+        <ContentWrapper>
+          <Outlet />
+        </ContentWrapper>
         <FooterWrapper>
           <Footer />
         </FooterWrapper>
@@ -22,18 +24,23 @@ function DefaultLayout() {
 export default DefaultLayout;
 
 const PageWrapper = styled.div`
-  width: 100vw;
+  max-width: 100vw;
   min-height: 100vh;
-  position: relative;
+  display: flex;
+  flex-direction: column;
 `;
+
 const HeaderWrapper = styled.div`
   width: 100%;
   position: fixed;
   top: 0;
 `;
 
+const ContentWrapper = styled.div`
+  padding-top: 70px;
+  min-height: calc(100vh - 330px);
+`;
+
 const FooterWrapper = styled.div`
   width: 100%;
-  position: absolute;
-  bottom: 0;
 `;

--- a/strawberry/src/layout/HeaderLayout.tsx
+++ b/strawberry/src/layout/HeaderLayout.tsx
@@ -9,7 +9,9 @@ function HeaderLayout() {
         <HeaderWrapper>
           <Header />
         </HeaderWrapper>
-        <Outlet />
+        <ContentWrapper>
+          <Outlet />
+        </ContentWrapper>
       </PageWrapper>
     </>
   );
@@ -18,13 +20,19 @@ function HeaderLayout() {
 export default HeaderLayout;
 
 const PageWrapper = styled.div`
-  width: 100vw;
+  max-width: 100vw;
   min-height: 100vh;
-  position: relative;
+  display: flex;
+  flex-direction: column;
 `;
 
 const HeaderWrapper = styled.div`
   width: 100%;
   position: fixed;
   top: 0;
+`;
+
+const ContentWrapper = styled.div`
+  padding-top: 70px;
+  min-height: calc(100vh - 70px);
 `;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#31-add-Layout-css

### 💡 작업동기
- 레이아웃의 헤더, 푸터, 컨텐츠 영역의 css를 설정합니다.

### 🔑 주요 변경사항
- DefaultLayout css 적용
- HeaderLayout css 적용

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ad7c8d6e-9569-4e72-b094-5cd3e21718c9">


### 관련 이슈
- closed: #31 
