### PR TITLE
소셜 로그인을 구현합니다.

### DIFF
--- a/strawberry/src/core/contexts/globalContext.tsx
+++ b/strawberry/src/core/contexts/globalContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, Dispatch, useReducer, ReactNode } from "react";
+import {
+  createContext,
+  Dispatch,
+  useReducer,
+  ReactNode,
+  useEffect,
+} from "react";
 
 // User Data Types
 export type UserData = {
@@ -37,7 +43,7 @@ export const GlobalDispatchContext = createContext<
 
 // Actions
 type Action =
-  | { type: "LOGIN"; status: boolean }
+  | { type: "SET_LOGIN"; status: boolean }
   | { type: "LOGOUT"; status: boolean }
   | { type: "UPDATE_USER"; data: UserData }
   | {
@@ -52,9 +58,7 @@ type Action =
 // Reducer
 function globalReducer(state: GlobalState, action: Action): GlobalState {
   switch (action.type) {
-    case "LOGIN":
-      return { ...state, isLogin: action.status };
-    case "LOGOUT":
+    case "SET_LOGIN":
       return { ...state, isLogin: action.status };
     case "UPDATE_USER":
       return { ...state, user: action.data };
@@ -86,6 +90,11 @@ export function GlobalContextProvider({ children }: { children: ReactNode }) {
     modalCategory: null,
     modalProps: null,
   });
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    dispatch({ type: "SET_LOGIN", status: accessToken !== null });
+  }, []);
 
   return (
     <GlobalDispatchContext.Provider value={dispatch}>

--- a/strawberry/src/core/contexts/globalContext.tsx
+++ b/strawberry/src/core/contexts/globalContext.tsx
@@ -44,7 +44,6 @@ export const GlobalDispatchContext = createContext<
 // Actions
 type Action =
   | { type: "SET_LOGIN"; status: boolean }
-  | { type: "LOGOUT"; status: boolean }
   | { type: "UPDATE_USER"; data: UserData }
   | {
       type: "OPEN_MODAL";

--- a/strawberry/src/data/config/url.tsx
+++ b/strawberry/src/data/config/url.tsx
@@ -7,7 +7,7 @@ export function buildURL(
 
   if (params) {
     Object.keys(params).forEach((key) => {
-      finalURL += params[key];
+      finalURL += "/" + params[key];
     });
   }
 

--- a/strawberry/src/data/config/useFetch.tsx
+++ b/strawberry/src/data/config/useFetch.tsx
@@ -20,7 +20,9 @@ export function useFetch<T>({
   body,
 }: RequestConfig<T>): () => Promise<T> {
   return async () => {
-    const finalURL = buildURL(url, params, queryParams);
+    const Server_IP = `${import.meta.env.VITE_APP_Server_IP}/api/v1/`;
+    const finalURL = Server_IP + buildURL(url, params, queryParams);
+
     const finalHeader = { "Content-Type": "application/json" };
     const finalBody = body ? JSON.stringify(body) : undefined;
 

--- a/strawberry/src/layout/HeaderLayout.tsx
+++ b/strawberry/src/layout/HeaderLayout.tsx
@@ -1,9 +1,13 @@
 import Header from "./components/header";
-import { Outlet } from "react-router-dom";
+import React from "react";
 import { Wrapper } from "../core/design_system";
 import { Modal } from "../pages/common/components/modal/Modal";
 
-function HeaderLayout() {
+interface HeaderLayoutProps {
+  children?: React.ReactNode;
+}
+
+function HeaderLayout({ children }: HeaderLayoutProps) {
   return (
     <>
       {/* LayoutWrapper */}
@@ -20,7 +24,7 @@ function HeaderLayout() {
         </Wrapper>
         {/* PageWrapper */}
         <Wrapper $padding="70px 0 0 0" width="100%">
-          <Outlet />
+          {children}
         </Wrapper>
       </Wrapper>
     </>

--- a/strawberry/src/pages/login/LoginRedirectPage.tsx
+++ b/strawberry/src/pages/login/LoginRedirectPage.tsx
@@ -1,0 +1,14 @@
+import { useHandleLoginRedirect } from "./hooks/useHandleLoginRedirect";
+
+function LoginRedirectedPage() {
+  useHandleLoginRedirect();
+
+  return (
+    <div>
+      <h1>리다이렉트된 페이지</h1>
+      <p>소셜 로그인 처리 중입니다...</p>
+    </div>
+  );
+}
+
+export default LoginRedirectedPage;

--- a/strawberry/src/pages/login/hooks/useHandleLoginRedirect.tsx
+++ b/strawberry/src/pages/login/hooks/useHandleLoginRedirect.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import useLoginCallbackQuery from "./useLoginCallbackQuery";
+import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
+
+export function useHandleLoginRedirect() {
+  const navigate = useNavigate();
+
+  const queryParams = new URLSearchParams(window.location.search);
+  const type = queryParams.get("state") || "";
+  const code = queryParams.get("code") || "";
+
+  const dispatch = useGlobalDispatch();
+  const { data, error } = useLoginCallbackQuery(type, code);
+
+  useEffect(() => {
+    if (data) {
+      const { user, token } = data.data;
+
+      localStorage.setItem("accessToken", token.accessToken);
+      dispatch?.({ type: "SET_LOGIN", status: true });
+
+      navigate("/");
+    }
+
+    if (error) {
+      console.error("로그인 처리 중 에러 발생:", error);
+    }
+  }, [data, error, navigate]);
+}

--- a/strawberry/src/pages/login/hooks/useLogin.tsx
+++ b/strawberry/src/pages/login/hooks/useLogin.tsx
@@ -2,7 +2,7 @@ const Server_IP = import.meta.env.VITE_APP_Server_IP;
 
 export function useLogin() {
   function locateLoginPage({ social }: { social: string }) {
-    window.location.href = `${Server_IP}/oauth2/${social}`;
+    window.location.href = `${Server_IP}/api/v1/oauth2/${social}`;
   }
 
   return locateLoginPage;

--- a/strawberry/src/pages/login/hooks/useLoginCallbackQuery.tsx
+++ b/strawberry/src/pages/login/hooks/useLoginCallbackQuery.tsx
@@ -35,7 +35,6 @@ export function useLoginCallbackQuery(type: string, code: string) {
   const query = useQuery<Oauth, Error>({
     queryKey: ["oauth"],
     queryFn: getLoginCallback,
-    enabled: !!code,
   });
 
   return query;

--- a/strawberry/src/pages/login/hooks/useLoginCallbackQuery.tsx
+++ b/strawberry/src/pages/login/hooks/useLoginCallbackQuery.tsx
@@ -1,0 +1,44 @@
+import { useQuery } from "react-query";
+import { useFetch } from "../../../data/config/useFetch";
+
+interface User {
+  email: string;
+  name: string;
+  birthdate: string;
+}
+
+interface Token {
+  accessToken: string;
+}
+
+interface OauthData {
+  user: User;
+  token: Token;
+}
+
+interface Oauth {
+  status: number;
+  message: string;
+  data: OauthData;
+}
+
+export function useLoginCallbackQuery(type: string, code: string) {
+  const getLoginCallback = useFetch<Oauth>({
+    url: `oauth2/${type}/callback`,
+    method: "GET",
+    queryParams: {
+      code: code,
+      state: type,
+    },
+  });
+
+  const query = useQuery<Oauth, Error>({
+    queryKey: ["oauth"],
+    queryFn: getLoginCallback,
+    enabled: !!code,
+  });
+
+  return query;
+}
+
+export default useLoginCallbackQuery;

--- a/strawberry/src/router/ProtectedRoute.tsx
+++ b/strawberry/src/router/ProtectedRoute.tsx
@@ -1,7 +1,17 @@
-import { Outlet } from "react-router-dom";
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+import { useGlobalDispatch } from "../core/hooks/useGlobalDispatch";
 
 function ProtectedRoute() {
-  // 로그인 하지 않으면 navigate
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+
+    if (!token) {
+      navigate("/login");
+    }
+  }, [navigate]);
 
   return <Outlet />;
 }

--- a/strawberry/src/router/router.tsx
+++ b/strawberry/src/router/router.tsx
@@ -9,6 +9,7 @@ import QuizPlayPage from "../pages/quiz/QuizPlayPage";
 import DrawingPlayPage from "../pages/drawing/DrawingPlayPage";
 import DrawingLandingPage from "../pages/drawingLanding/DrawingLandingPage";
 import LoginPage from "../pages/login/LoginPage";
+import LoginRedirectedPage from "../pages/login/LoginRedirectPage";
 
 const router = createBrowserRouter([
   {
@@ -48,9 +49,11 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: (
-      <HeaderLayout>
-        <ProtectedRoute />
-      </HeaderLayout>
+      <>
+        <HeaderLayout>
+          <ProtectedRoute />
+        </HeaderLayout>
+      </>
     ),
     children: [
       {
@@ -77,7 +80,11 @@ const router = createBrowserRouter([
   },
   {
     path: "auth/:sns/callback",
-    element: <PublicRoute>{/* <LoginRedirectPage /> */}</PublicRoute>,
+    element: (
+      <PublicRoute>
+        <LoginRedirectedPage /> {/* 리다이렉트 페이지 렌더링 */}
+      </PublicRoute>
+    ),
   },
 ]);
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
feat/#55-social-login

### 💡 작업동기
- 소셜 로그인을 작업합니다.
- 현대, 네이버 둘 다 작업합니다.

### 🔑 주요 변경사항
- `.env` 파일 안에 url을 수정합니다. `/api/v1/` 은 useFetch안으로 옮겨두었습니다.
- protected route 기능을 추가해서, 토큰이 없는 경우(로그인 하지 않은 경우) play까지 도달하지 못 합니다.
- 직접 url을 쳐서 들어가도 로그인 유효성 검사 다시 합니다!
- token은 localStorage에 저장하였고, 일반적으로 저희는 global context 안에 있는 isLogin state를 사용하여 검사합니다.

### 🏞 스크린샷
<img width="823" alt="image" src="https://github.com/user-attachments/assets/12f82088-a8bf-4891-ba91-0ec066085de7">


### 관련 이슈
closed: #55 
