### PR TITLE
기대평 페이지 API를 연동합니다.

### DIFF
--- a/strawberry/src/pages/expectation/ExpectationPage.tsx
+++ b/strawberry/src/pages/expectation/ExpectationPage.tsx
@@ -1,7 +1,14 @@
 import { useEffect } from "react";
-
 import styled from "styled-components";
+
 import { Label, theme, Wrapper } from "../../core/design_system";
+import { throttle } from "../../core/utils";
+
+import { EventNotice } from "../common/components";
+
+import useExpectationData from "./hooks/useExpectationData";
+import { useExpectationState } from "./hooks/useExpectationState";
+import { useExpectationDispatch } from "./hooks/useExpectationDispatch";
 
 import {
   ExpectationTitle,
@@ -10,14 +17,6 @@ import {
   ExpectationList,
   Pagination,
 } from "./components";
-import { EventNotice } from "../common/components";
-
-import useExpectationData from "./hooks/useExpectationData";
-
-import { useExpectationState } from "./hooks/useExpectationState";
-import { useExpectationDispatch } from "./hooks/useExpectationDispatch";
-
-import { throttle } from "../../core/utils";
 
 function ExpectationPage() {
   const { expectationList, nowPage, totalPage, changePage, bannerImg } =

--- a/strawberry/src/pages/expectation/ExpectationPage.tsx
+++ b/strawberry/src/pages/expectation/ExpectationPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect } from "react";
 
 import styled from "styled-components";
 import { Label, theme, Wrapper } from "../../core/design_system";
@@ -12,11 +12,16 @@ import {
 } from "./components";
 import { EventNotice } from "../common/components";
 
-import { ExpectationListProps } from "./contexts/useExpectationListQuery";
+import useExpectationData from "./hooks/useExpectationData";
+
+import { useExpectationState } from "./hooks/useExpectationState";
+import { useExpectationDispatch } from "./hooks/useExpectationDispatch";
+
+import { throttle } from "../../core/utils";
 
 function ExpectationPage() {
-  const totalpage = expectations.length;
-  const [nowPage, setNowPage] = useState(1);
+  const { expectationList, nowPage, totalPage, changePage, bannerImg } =
+    useExpectationPage();
 
   return (
     <>
@@ -24,7 +29,7 @@ function ExpectationPage() {
         <ExpectationTitle />
         {/* content Wrapper */}
         <ExpectationContentWrapper>
-          <ExpectationBanner />
+          <ExpectationBanner bannerImg={bannerImg} />
           <Label
             $margin="48px 0 0 0"
             width="100%"
@@ -45,25 +50,19 @@ function ExpectationPage() {
             display="flex"
             $flexdirection="column"
             $margin="40px 0 0 0"
-            $justifycontent="center"
             $alignitems="center"
+            $minheight="1276px"
           >
-            {expectations[nowPage - 1].map(
-              ({ writerName, content }: ExpectationListProps, idx: number) => (
-                <ExpectationList
-                  key={idx}
-                  writerName={writerName}
-                  content={content}
-                />
-              ),
-            )}
-          </Wrapper>
-          <Wrapper $margin="0 0 80px 0">
-            <Pagination
-              totalPages={totalpage}
-              currentPage={nowPage}
-              onPageChange={(page) => setNowPage(page)}
-            />
+            {expectationList?.map(({ name, comment }, idx) => (
+              <ExpectationList key={idx} name={name} comment={comment} />
+            ))}
+            <Wrapper $margin="0 0 80px 0">
+              <Pagination
+                totalPages={totalPage}
+                currentPage={nowPage}
+                onPageChange={(page) => changePage(page)}
+              />
+            </Wrapper>
           </Wrapper>
         </ExpectationContentWrapper>
         <EventNotice title="기대평 유의사항" notices={notices} />
@@ -73,6 +72,29 @@ function ExpectationPage() {
 }
 
 export default ExpectationPage;
+
+function useExpectationPage() {
+  const { refetchList } = useExpectationData();
+  const { expectationList, nowPage, totalPage, bannerImg } =
+    useExpectationState();
+  const dispatch = useExpectationDispatch();
+
+  useEffect(() => {
+    refetchList();
+  }, [nowPage, refetchList]);
+
+  const changePage = throttle()((page: number) => {
+    dispatch({ type: "SET_NOW_PAGE", payload: page });
+  });
+
+  return {
+    expectationList,
+    nowPage,
+    totalPage,
+    changePage,
+    bannerImg,
+  };
+}
 
 const ExpectationWrapper = styled.div`
   position: relative;
@@ -90,87 +112,6 @@ const ExpectationContentWrapper = styled.div`
   flex-direction: column;
   margin: 193px 0 0 0;
 `;
-
-const expectations = [
-  [
-    {
-      writerName: "최*빈",
-      content:
-        "디 올 뉴 싼타페의 새로운 디자인이 정말 기대돼요. 현대차의 혁신적인 디자인 언어가 어떻게 반영됐을지 궁금하네요! 하이브리드 모델도 나온다고 하니, 친환경적인 측면에서도 얼마나 발전했을지 기대됩니다. 실내 인테리어가 고급스러워졌다는 이야기를 들었어요. 고급 소재와 세련된 디자인이 어떻게 적용됐을지 궁금합니다.",
-    },
-    {
-      writerName: "최*우",
-      content:
-        "첨단 기술이 탑재된다고 들었는데, 디지털 센터 미러와 스마트한 인포테인먼트 시스템이 얼마나 향상됐을지 기대됩니다. 연비가 개선됐다고 들었어요. 장거리 운전 시 경제성을 얼마나 느낄 수 있을지 기대됩니다.",
-    },
-    {
-      writerName: "윤*린",
-      content:
-        "실내 공간이 더욱 넓어지고 편안해졌다고 하는데, 가족 여행에 딱 맞는 SUV가 될 것 같아요.",
-    },
-    {
-      writerName: "최*빈",
-      content:
-        "디 올 뉴 싼타페의 새로운 디자인이 정말 기대돼요. 현대차의 혁신적인 디자인 언어가 어떻게 반영됐을지 궁금하네요! 하이브리드 모델도 나온다고 하니, 친환경적인 측면에서도 얼마나 발전했을지 기대됩니다. 실내 인테리어가 고급스러워졌다는 이야기를 들었어요. 고급 소재와 세련된 디자인이 어떻게 적용됐을지 궁금합니다.",
-    },
-  ],
-  [
-    {
-      writerName: "최*우",
-      content:
-        "첨단 기술이 탑재된다고 들었는데, 디지털 센터 미러와 스마트한 인포테인먼트 시스템이 얼마나 향상됐을지 기대됩니다. 연비가 개선됐다고 들었어요. 장거리 운전 시 경제성을 얼마나 느낄 수 있을지 기대됩니다.",
-    },
-    {
-      writerName: "윤*린",
-      content:
-        "실내 공간이 더욱 넓어지고 편안해졌다고 하는데, 가족 여행에 딱 맞는 SUV가 될 것 같아요.",
-    },
-    {
-      writerName: "최*빈",
-      content:
-        "디 올 뉴 싼타페의 새로운 디자인이 정말 기대돼요. 현대차의 혁신적인 디자인 언어가 어떻게 반영됐을지 궁금하네요! 하이브리드 모델도 나온다고 하니, 친환경적인 측면에서도 얼마나 발전했을지 기대됩니다. 실내 인테리어가 고급스러워졌다는 이야기를 들었어요. 고급 소재와 세련된 디자인이 어떻게 적용됐을지 궁금합니다.",
-    },
-    {
-      writerName: "최*우",
-      content:
-        "첨단 기술이 탑재된다고 들었는데, 디지털 센터 미러와 스마트한 인포테인먼트 시스템이 얼마나 향상됐을지 기대됩니다. 연비가 개선됐다고 들었어요. 장거리 운전 시 경제성을 얼마나 느낄 수 있을지 기대됩니다.",
-    },
-  ],
-  [
-    {
-      writerName: "윤*린",
-      content:
-        "실내 공간이 더욱 넓어지고 편안해졌다고 하는데, 가족 여행에 딱 맞는 SUV가 될 것 같아요.",
-    },
-    {
-      writerName: "최*우",
-      content:
-        "첨단 기술이 탑재된다고 들었는데, 디지털 센터 미러와 스마트한 인포테인먼트 시스템이 얼마나 향상됐을지 기대됩니다. 연비가 개선됐다고 들었어요. 장거리 운전 시 경제성을 얼마나 느낄 수 있을지 기대됩니다.",
-    },
-    {
-      writerName: "윤*린",
-      content:
-        "실내 공간이 더욱 넓어지고 편안해졌다고 하는데, 가족 여행에 딱 맞는 SUV가 될 것 같아요.",
-    },
-    {
-      writerName: "최*빈",
-      content:
-        "디 올 뉴 싼타페의 새로운 디자인이 정말 기대돼요. 현대차의 혁신적인 디자인 언어가 어떻게 반영됐을지 궁금하네요! 하이브리드 모델도 나온다고 하니, 친환경적인 측면에서도 얼마나 발전했을지 기대됩니다. 실내 인테리어가 고급스러워졌다는 이야기를 들었어요. 고급 소재와 세련된 디자인이 어떻게 적용됐을지 궁금합니다.",
-    },
-  ],
-  [
-    {
-      writerName: "최*우",
-      content:
-        "첨단 기술이 탑재된다고 들었는데, 디지털 센터 미러와 스마트한 인포테인먼트 시스템이 얼마나 향상됐을지 기대됩니다. 연비가 개선됐다고 들었어요. 장거리 운전 시 경제성을 얼마나 느낄 수 있을지 기대됩니다.",
-    },
-    {
-      writerName: "윤*린",
-      content:
-        "실내 공간이 더욱 넓어지고 편안해졌다고 하는데, 가족 여행에 딱 맞는 SUV가 될 것 같아요.",
-    },
-  ],
-];
 
 const notices = [
   "이벤트 기간은 2024년 9월 1일 오후 12시부터 2024년 9월 21일 오후 10시까지입니다. 기간 내에 작성된 기대평만 유효합니다.",

--- a/strawberry/src/pages/expectation/ExpectationPage.tsx
+++ b/strawberry/src/pages/expectation/ExpectationPage.tsx
@@ -1,14 +1,10 @@
-import { useEffect } from "react";
 import styled from "styled-components";
 
 import { Label, theme, Wrapper } from "../../core/design_system";
-import { throttle } from "../../core/utils";
 
 import { EventNotice } from "../common/components";
 
-import useExpectationData from "./hooks/useExpectationData";
-import { useExpectationState } from "./hooks/useExpectationState";
-import { useExpectationDispatch } from "./hooks/useExpectationDispatch";
+import useExpectationPage from "./hooks/logics/useExpectationPage";
 
 import {
   ExpectationTitle,
@@ -71,29 +67,6 @@ function ExpectationPage() {
 }
 
 export default ExpectationPage;
-
-function useExpectationPage() {
-  const { refetchList } = useExpectationData();
-  const { expectationList, nowPage, totalPage, bannerImg } =
-    useExpectationState();
-  const dispatch = useExpectationDispatch();
-
-  useEffect(() => {
-    refetchList();
-  }, [nowPage, refetchList]);
-
-  const changePage = throttle()((page: number) => {
-    dispatch({ type: "SET_NOW_PAGE", payload: page });
-  });
-
-  return {
-    expectationList,
-    nowPage,
-    totalPage,
-    changePage,
-    bannerImg,
-  };
-}
 
 const ExpectationWrapper = styled.div`
   position: relative;

--- a/strawberry/src/pages/expectation/ExpectationPageWrapper.tsx
+++ b/strawberry/src/pages/expectation/ExpectationPageWrapper.tsx
@@ -1,0 +1,13 @@
+import { ExpectationContextProvider } from "./contexts/expectationContext";
+
+import ExpectationPage from "./ExpectationPage";
+
+function ExpectationPageWrapper() {
+  return (
+    <ExpectationContextProvider>
+      <ExpectationPage />
+    </ExpectationContextProvider>
+  );
+}
+
+export default ExpectationPageWrapper;

--- a/strawberry/src/pages/expectation/components/ExpectationBanner.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationBanner.tsx
@@ -1,8 +1,11 @@
 import styled from "styled-components";
-import expectationBG from "/src/assets/images/background/expectationBG.svg";
 
-function ExpectationBanner() {
-  return <StyledImg src={expectationBG} />;
+interface ExpectationBannerProps {
+  bannerImg: string;
+}
+
+function ExpectationBanner({ bannerImg }: ExpectationBannerProps) {
+  return <StyledImg src={bannerImg} />;
 }
 
 export default ExpectationBanner;

--- a/strawberry/src/pages/expectation/components/ExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationInput.tsx
@@ -1,38 +1,41 @@
+import SubmitButton from "./SubmitButton";
+
 import styled from "styled-components";
 import { Wrapper } from "../../../core/design_system";
 
-import SubmitButton from "./SubmitButton";
-
-import useLengthValidation from "../hooks/useLengthValidation";
+import useExpectationInput from "../hooks/logics/useExpectationInput";
 
 function ExpectationInput() {
-  const { content, handleChange } = useLengthValidation({
-    initialContent: "",
-    maxLength: 300,
-  });
-
-  function handleClick() {
-    // content fetch + 비속어 체크
-  }
+  const {
+    content,
+    handleChange,
+    handleKeyDown,
+    handleSubmit,
+    isFocused,
+    setIsFocused,
+  } = useExpectationInput();
 
   return (
     <Wrapper width="960px" display="flex" $justifycontent="space-between">
-      <InputWrapper>
+      <InputWrapper $isFocused={isFocused}>
         <StyledInput
           placeholder="디 올 뉴 싼타페에 대한 기대평을 작성해주세요"
           value={content}
           onChange={handleChange}
+          onKeyDown={(e) => handleKeyDown(e)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
         />
         <WrittenLength>{content.length}/300</WrittenLength>
       </InputWrapper>
-      <SubmitButton onClick={handleClick} />
+      <SubmitButton onClick={handleSubmit} />
     </Wrapper>
   );
 }
 
 export default ExpectationInput;
 
-const InputWrapper = styled.div`
+const InputWrapper = styled.div<{ $isFocused: boolean }>`
   border-radius: ${({ theme }) => theme.Border.Radius6};
   border: 1px solid ${({ theme }) => theme.Color.Border.default};
   padding: 12px;
@@ -43,6 +46,9 @@ const InputWrapper = styled.div`
   display: flex;
   flex-direction: row;
   background-color: ${({ theme }) => theme.Color.Common.white};
+
+  outline: ${({ theme, $isFocused }) =>
+    $isFocused ? `1px solid ${theme.Color.Primary.normal}` : "none"};
 `;
 
 const StyledInput = styled.textarea`

--- a/strawberry/src/pages/expectation/components/ExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationInput.tsx
@@ -1,9 +1,9 @@
-import SubmitButton from "./SubmitButton";
-
 import styled from "styled-components";
+
 import { Wrapper } from "../../../core/design_system";
 
 import useExpectationInput from "../hooks/logics/useExpectationInput";
+import SubmitButton from "./SubmitButton";
 
 function ExpectationInput() {
   const {

--- a/strawberry/src/pages/expectation/components/ExpectationList.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationList.tsx
@@ -1,9 +1,10 @@
 import styled from "styled-components";
 import { Label, theme } from "../../../core/design_system";
 
-import { ExpectationListProps } from "../contexts/useExpectationListQuery";
+import { ExpectationListProps } from "../hooks/apis/useExpectationListQuery";
 
-function ExpectationList({ writerName, content }: ExpectationListProps) {
+function ExpectationList(props: ExpectationListProps) {
+  const { name, comment } = props;
   return (
     <>
       <ExpectationListWrapper>
@@ -12,14 +13,14 @@ function ExpectationList({ writerName, content }: ExpectationListProps) {
           $token="Body1LongRegular"
           color={theme.Color.Primary.normal}
         >
-          {writerName}
+          {name}
         </Label>
         <Label
           width="100%"
           $token="Heading2Regular"
           color={theme.Color.TextIcon.default}
         >
-          {content}
+          {comment}
         </Label>
       </ExpectationListWrapper>
     </>

--- a/strawberry/src/pages/expectation/components/ExpectationList.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationList.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { Label, theme } from "../../../core/design_system";
 
 import { ExpectationListProps } from "../hooks/apis/useExpectationListQuery";

--- a/strawberry/src/pages/expectation/components/ExpectationTitle.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationTitle.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { theme, Label } from "../../../core/design_system";
 
 function ExpectationTitle() {

--- a/strawberry/src/pages/expectation/components/Pagination.tsx
+++ b/strawberry/src/pages/expectation/components/Pagination.tsx
@@ -1,10 +1,9 @@
 import styled from "styled-components";
 
-import Arrow_Left_L_Gray from "/src/assets/images/icons/Arrow_Left_L_Gray.svg";
-import Arrow_Right_L_Gray from "/src/assets/images/icons/Arrow_Right_L_Gray.svg";
-
 import usePagination from "../hooks/logics/usePagination";
 
+import Arrow_Left_L_Gray from "/src/assets/images/icons/Arrow_Left_L_Gray.svg";
+import Arrow_Right_L_Gray from "/src/assets/images/icons/Arrow_Right_L_Gray.svg";
 export interface PaginationProps {
   totalPages: number;
   currentPage: number;

--- a/strawberry/src/pages/expectation/components/Pagination.tsx
+++ b/strawberry/src/pages/expectation/components/Pagination.tsx
@@ -3,9 +3,9 @@ import styled from "styled-components";
 import Arrow_Left_L_Gray from "/src/assets/images/icons/Arrow_Left_L_Gray.svg";
 import Arrow_Right_L_Gray from "/src/assets/images/icons/Arrow_Right_L_Gray.svg";
 
-import usePagination from "../hooks/usePagination";
+import usePagination from "../hooks/logics/usePagination";
 
-interface PaginationProps {
+export interface PaginationProps {
   totalPages: number;
   currentPage: number;
   onPageChange: (arg: number) => void;
@@ -18,30 +18,8 @@ interface PageNumberProps {
 const Pagination = (props: PaginationProps) => {
   const { totalPages, currentPage, onPageChange } = props;
 
-  // 한 번에 보여줄 페이지 정의
-  const pagesToShow = 5;
-
-  const { visiblePages, updateVisiblePages } = usePagination({
-    totalPages,
-    pagesToShow,
-  });
-
-  const handlePage = (page: number) => {
-    onPageChange(page);
-    updateVisiblePages(page);
-  };
-
-  const handlePrevious = () => {
-    if (currentPage > 1) {
-      onPageChange(currentPage - 1);
-    }
-  };
-
-  const handleNext = () => {
-    if (currentPage < totalPages) {
-      onPageChange(currentPage + 1);
-    }
-  };
+  const { visiblePages, handlePage, handlePrevious, handleNext } =
+    usePagination({ totalPages, currentPage, onPageChange });
 
   return (
     <PaginationWrapper>
@@ -128,6 +106,6 @@ const PageNumber = styled.button<PageNumberProps>`
 
   &:hover {
     background-color: ${({ theme, $active }) =>
-      $active ? theme.Color.Primary.normal : theme.Color.TextIcon.reverse};
+    $active ? theme.Color.Primary.normal : theme.Color.TextIcon.reverse};
   }
 `;

--- a/strawberry/src/pages/expectation/contexts/expectationContext.tsx
+++ b/strawberry/src/pages/expectation/contexts/expectationContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useReducer, ReactNode } from "react";
+import { Dispatch } from "react";
+
+// 타입 정의
+interface ExpectationType {
+  name: string;
+  comment: string;
+}
+
+export interface ExpectationContextType {
+  nowPage: number;
+  totalPage: number;
+  bannerImg: string;
+  expectationList: ExpectationType[];
+}
+
+export type ExpectationActionType =
+  | { type: "SET_NOW_PAGE"; payload: number }
+  | { type: "SET_TOTAL_PAGE"; payload: number }
+  | { type: "SET_EXPECTATION_LIST"; payload: ExpectationType[] }
+  | { type: "SET_BANNER_IMG"; payload: string };
+
+// 초기 상태
+const initialState: ExpectationContextType = {
+  nowPage: 1,
+  totalPage: 1,
+  bannerImg: "",
+  expectationList: [],
+};
+
+// 리듀서 함수
+const reducer = (
+  state: ExpectationContextType,
+  action: ExpectationActionType,
+): ExpectationContextType => {
+  switch (action.type) {
+    case "SET_NOW_PAGE":
+      return { ...state, nowPage: action.payload };
+    case "SET_TOTAL_PAGE":
+      return { ...state, totalPage: action.payload };
+    case "SET_EXPECTATION_LIST":
+      return { ...state, expectationList: action.payload };
+    case "SET_BANNER_IMG":
+      return { ...state, bannerImg: action.payload };
+  }
+};
+
+export const ExpectationStateContext = createContext<
+  ExpectationContextType | undefined
+>(undefined);
+
+export const ExpectationDispatchContext = createContext<
+  Dispatch<ExpectationActionType> | undefined
+>(undefined);
+
+// Context Provider 컴포넌트
+export const ExpectationContextProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <ExpectationStateContext.Provider value={state}>
+      <ExpectationDispatchContext.Provider value={dispatch}>
+        {children}
+      </ExpectationDispatchContext.Provider>
+    </ExpectationStateContext.Provider>
+  );
+};

--- a/strawberry/src/pages/expectation/contexts/expectationContext.tsx
+++ b/strawberry/src/pages/expectation/contexts/expectationContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useReducer, ReactNode } from "react";
 import { Dispatch } from "react";
 
 // 타입 정의
-interface ExpectationType {
+export interface ExpectationType {
   name: string;
   comment: string;
 }

--- a/strawberry/src/pages/expectation/contexts/useExpectationListQuery.tsx
+++ b/strawberry/src/pages/expectation/contexts/useExpectationListQuery.tsx
@@ -1,4 +1,0 @@
-export interface ExpectationListProps {
-  writerName: string;
-  content: string;
-}

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationListQuery.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationListQuery.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+
 import { useFetch } from "../../../../data/config/useFetch";
 
 import { useExpectationState } from "../useExpectationState";

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationListQuery.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationListQuery.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from "react-query";
+import { useFetch } from "../../../../data/config/useFetch";
+
+import { useExpectationState } from "../useExpectationState";
+
+export interface ExpectationListProps {
+  name: string;
+  comment: string;
+}
+
+export function useExpectationListQuery() {
+  const getExpectationList = useFetch({
+    url: "expectation/page",
+    method: "GET",
+    queryParams: {
+      pageSequence: String(useExpectationState().nowPage - 1),
+    },
+  });
+
+  const query = useQuery({
+    queryKey: ["expecationList"],
+    queryFn: getExpectationList,
+  });
+
+  return query;
+}

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationMutation.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationMutation.tsx
@@ -1,0 +1,24 @@
+import { useMutation } from "react-query";
+import { useFetch } from "../../../../data/config/useFetch";
+
+export interface useExpectationMutationBodyType {
+  body: {
+    content: string;
+  };
+}
+
+export function useExpectationMutation() {
+  const fetchFn = useFetch({
+    url: "expectation",
+    method: "POST",
+  });
+
+  const mutation = useMutation({
+    mutationFn: fetchFn,
+    onSuccess: () => location.reload(),
+  });
+
+  return mutation;
+}
+
+export default useExpectationMutation;

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationMutation.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationMutation.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from "react-query";
+
 import { useFetch } from "../../../../data/config/useFetch";
 
 export interface useExpectationMutationBodyType {

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationMutation.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationMutation.tsx
@@ -2,10 +2,8 @@ import { useMutation } from "react-query";
 
 import { useFetch } from "../../../../data/config/useFetch";
 
-export interface useExpectationMutationBodyType {
-  body: {
-    content: string;
-  };
+interface UseExpectationMutationBodyType {
+  comment: string;
 }
 
 export function useExpectationMutation() {
@@ -15,7 +13,8 @@ export function useExpectationMutation() {
   });
 
   const mutation = useMutation({
-    mutationFn: fetchFn,
+    mutationFn: ({ body }: { body: UseExpectationMutationBodyType }) =>
+      fetchFn({ body: body }),
     onSuccess: () => location.reload(),
   });
 

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationPageQuery.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationPageQuery.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "react-query";
+import { useFetch } from "../../../../data/config/useFetch";
+
+export function useExpectationPageQuery() {
+  const getExpectationPage = useFetch({
+    url: "expectation/land",
+    method: "GET",
+  });
+
+  const query = useQuery({
+    queryKey: ["expectationPage"],
+    queryFn: getExpectationPage,
+  });
+
+  return query;
+}

--- a/strawberry/src/pages/expectation/hooks/apis/useExpectationPageQuery.tsx
+++ b/strawberry/src/pages/expectation/hooks/apis/useExpectationPageQuery.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+
 import { useFetch } from "../../../../data/config/useFetch";
 
 export function useExpectationPageQuery() {

--- a/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import useLengthValidation from "../useLengthValidation";
+import useExpectationMutation from "../apis/useExpectationMutation";
+import { useGlobalState } from "../../../../core/hooks/useGlobalState";
+import { useGlobalDispatch } from "../../../../core/hooks/useGlobalDispatch";
+
+import { throttle } from "../../../../core/utils";
+
+function useExpectationInput() {
+  const { mutate: postExpectation } = useExpectationMutation();
+  const [isFocused, setIsFocused] = useState(false);
+  const { content, handleChange } = useLengthValidation({
+    initialContent: "",
+    maxLength: 300,
+  });
+
+  const { isLogin } = useGlobalState();
+  const navigate = useNavigate();
+
+  const globalDispatch = useGlobalDispatch();
+
+  const handleSubmit = throttle()(() => {
+    if (content.length === 0) {
+      alert("내용을 입력해주세요.");
+      return;
+    }
+
+    if (!isLogin) {
+      globalDispatch?.({
+        type: "OPEN_MODAL",
+        modalCategory: "TWO_BUTTON",
+        modalProps: {
+          info: "로그인 후 이용 가능한 서비스입니다.\n로그인하시겠습니까?",
+          whiteBtnContent: "취소",
+          primaryBtnContent: "확인",
+          onWhiteBtnClick: () => globalDispatch({ type: "CLOSE_MODAL" }),
+          onPrimaryBtnClick: () => {
+            globalDispatch({ type: "CLOSE_MODAL" });
+            navigate("/login");
+          },
+        },
+      });
+      return;
+    }
+
+    postExpectation({ body: { comment: content } });
+  });
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  return {
+    content,
+    handleChange,
+    handleKeyDown,
+    handleSubmit,
+    isFocused,
+    setIsFocused,
+  };
+}
+
+export default useExpectationInput;

--- a/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import useLengthValidation from "../useLengthValidation";
-import useExpectationMutation from "../apis/useExpectationMutation";
 import { useGlobalState } from "../../../../core/hooks/useGlobalState";
 import { useGlobalDispatch } from "../../../../core/hooks/useGlobalDispatch";
-
 import { throttle } from "../../../../core/utils";
+
+import useLengthValidation from "../useLengthValidation";
+import useExpectationMutation from "../apis/useExpectationMutation";
 
 function useExpectationInput() {
   const { mutate: postExpectation } = useExpectationMutation();

--- a/strawberry/src/pages/expectation/hooks/logics/useExpectationPage.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/useExpectationPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+
+import { throttle } from "../../../../core/utils";
+
+import useExpectationData from "../useExpectationData";
+import { useExpectationState } from "../useExpectationState";
+import { useExpectationDispatch } from "../useExpectationDispatch";
+import { ExpectationType } from "../../contexts/expectationContext";
+
+interface UseExpectationPageType {
+  expectationList: ExpectationType[];
+  nowPage: number;
+  totalPage: number;
+  changePage: () => void;
+  bannerImg: string;
+}
+
+function useExpectationPage(): UseExpectationPageType {
+  const { refetchList } = useExpectationData();
+  const { expectationList, nowPage, totalPage, bannerImg } =
+    useExpectationState();
+  const dispatch = useExpectationDispatch();
+
+  useEffect(() => {
+    refetchList();
+  }, [nowPage, refetchList]);
+
+  const changePage = throttle()((page: number) => {
+    dispatch({ type: "SET_NOW_PAGE", payload: page });
+  });
+
+  return {
+    expectationList,
+    nowPage,
+    totalPage,
+    changePage,
+    bannerImg,
+  };
+}
+
+export default useExpectationPage;

--- a/strawberry/src/pages/expectation/hooks/logics/usePagination.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/usePagination.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+
 import usePage from "../usePage";
 
 import { PaginationProps } from "../../components/Pagination";

--- a/strawberry/src/pages/expectation/hooks/logics/usePagination.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/usePagination.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import usePage from "../usePage";
+
+import { PaginationProps } from "../../components/Pagination";
+
+function usePagination(props: PaginationProps) {
+  const { totalPages, currentPage, onPageChange } = props;
+
+  const pagesToShow = 5;
+  const { visiblePages, updateVisiblePages } = usePage({
+    totalPages,
+    pagesToShow,
+  });
+
+  useEffect(() => {
+    updateVisiblePages(currentPage);
+  }, [currentPage, totalPages]);
+
+  const handlePage = (page: number) => {
+    onPageChange(page);
+    updateVisiblePages(page);
+  };
+
+  const handlePrevious = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPages) {
+      onPageChange(currentPage + 1);
+    }
+  };
+
+  return { visiblePages, handlePage, handlePrevious, handleNext };
+}
+
+export default usePagination;

--- a/strawberry/src/pages/expectation/hooks/useExpectationData.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationData.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { useExpectationPageQuery } from "./apis/useExpectationPageQuery";
+import { useExpectationListQuery } from "./apis/useExpectationListQuery";
+
+import { useExpectationDispatch } from "./useExpectationDispatch";
+
+function useExpectationData() {
+  const { data: pageData } = useExpectationPageQuery();
+  const { data: listData, refetch: refetchList } = useExpectationListQuery();
+  const dispatch = useExpectationDispatch();
+
+  useEffect(() => {
+    if (pageData) {
+      dispatch({
+        type: "SET_BANNER_IMG",
+        payload: pageData?.bannerImgUrl,
+      });
+    }
+  }, [pageData, dispatch]);
+
+  useEffect(() => {
+    if (listData) {
+      dispatch({
+        type: "SET_EXPECTATION_LIST",
+        payload: listData?.comments,
+      });
+      dispatch({
+        type: "SET_TOTAL_PAGE",
+        payload: listData?.totalPages,
+      });
+    }
+  }, [listData, dispatch]);
+
+  return { refetchList };
+}
+
+export default useExpectationData;

--- a/strawberry/src/pages/expectation/hooks/useExpectationData.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationData.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
+
 import { useExpectationPageQuery } from "./apis/useExpectationPageQuery";
 import { useExpectationListQuery } from "./apis/useExpectationListQuery";
-
 import { useExpectationDispatch } from "./useExpectationDispatch";
 
 function useExpectationData() {

--- a/strawberry/src/pages/expectation/hooks/useExpectationDispatch.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationDispatch.tsx
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+import { ExpectationDispatchContext } from "../contexts/expectationContext";
+
+export function useExpectationDispatch() {
+  const dispatch = useContext(ExpectationDispatchContext);
+  if (!dispatch)
+    throw new Error("Expectation Dispatch Context Provider Not Found");
+  return dispatch;
+}

--- a/strawberry/src/pages/expectation/hooks/useExpectationDispatch.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationDispatch.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+
 import { ExpectationDispatchContext } from "../contexts/expectationContext";
 
 export function useExpectationDispatch() {

--- a/strawberry/src/pages/expectation/hooks/useExpectationState.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationState.tsx
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { ExpectationStateContext } from "../contexts/expectationContext";
+
+export function useExpectationState() {
+  const state = useContext(ExpectationStateContext);
+  if (!state) throw new Error("Expectation State Context Provider Not Found");
+  return state;
+}

--- a/strawberry/src/pages/expectation/hooks/useExpectationState.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationState.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+
 import { ExpectationStateContext } from "../contexts/expectationContext";
 
 export function useExpectationState() {

--- a/strawberry/src/pages/expectation/hooks/usePage.tsx
+++ b/strawberry/src/pages/expectation/hooks/usePage.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 
-interface PaginationParams {
+interface PageProps {
   totalPages: number;
   pagesToShow: number;
 }
 
-const usePagination = ({ totalPages, pagesToShow }: PaginationParams) => {
+const usePage = ({ totalPages, pagesToShow }: PageProps) => {
   const [visiblePages, setVisiblePages] = useState(
     Array.from({ length: Math.min(totalPages, pagesToShow) }, (_, i) => i + 1),
   );
@@ -23,4 +23,4 @@ const usePagination = ({ totalPages, pagesToShow }: PaginationParams) => {
   return { visiblePages, updateVisiblePages };
 };
 
-export default usePagination;
+export default usePage;

--- a/strawberry/src/router/router.tsx
+++ b/strawberry/src/router/router.tsx
@@ -6,7 +6,7 @@ import ProtectedRoute from "./ProtectedRoute";
 import QuizPlayPage from "../pages/quiz/QuizPlayPage";
 import DrawingPlayPage from "../pages/drawing/DrawingPlayPage";
 import LoginPage from "../pages/login/LoginPage";
-import ExpectationPage from "../pages/expectation/ExpectationPage";
+import ExpectationPageWrapper from "../pages/expectation/ExpectationPageWrapper";
 import LoginRedirectedPage from "../pages/login/LoginRedirectPage";
 import QuizLandingWrapper from "../pages/quizLanding/QuizLandingWrapper";
 import DrawingLandingWrapper from "../pages/drawingLanding/DrawingLandingWrapper";
@@ -36,7 +36,7 @@ const router = createBrowserRouter([
         path: "expectation",
         element: (
           <>
-            <ExpectationPage />
+            <ExpectationPageWrapper />
           </>
         ),
       },


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#68-implement-expectation

### 💡 작업동기
- 기존 기대평 페이지에 API를 연동하여 페이지를 완성합니다.

### 🔑 주요 변경사항
- query, mutation 생성
- api 연동
- 커스텀 훅 생성
- throttle 적용
- wrapper 생성

### 🏞 스크린샷
![image](https://github.com/user-attachments/assets/65611136-89e7-4d20-a45f-179d61819b52)

### 관련 이슈
- closed: #68 
