### PR TITLE
로그인 상태를 검사하고 이벤트 페이지로 넘어갑니다.

### DIFF
--- a/strawberry/src/core/hooks/useCheckLogin.tsx
+++ b/strawberry/src/core/hooks/useCheckLogin.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { useGlobalDispatch } from "./useGlobalDispatch";
+import { useGlobalState } from "./useGlobalState";
+
+/**  Login 유효시 callback 함수 실행, 유효하지 않으면 Login Modal 띄우기 **/
+export function useCheckLogin(): (callback: () => void) => void {
+  const navigate = useNavigate();
+  const state = useGlobalState();
+  const dispatch = useGlobalDispatch();
+
+  return (callback: () => void) => {
+    if (state.isLogin) {
+      callback();
+    } else {
+      dispatch?.({
+        type: "OPEN_MODAL",
+        modalCategory: "TWO_BUTTON",
+        modalProps: {
+          info: "로그인 후 이용 가능한 서비스입니다.\n로그인하시겠습니까?",
+          whiteBtnContent: "취소",
+          primaryBtnContent: "확인",
+          onWhiteBtnClick: () => dispatch({ type: "CLOSE_MODAL" }),
+          onPrimaryBtnClick: () => {
+            dispatch({ type: "CLOSE_MODAL" });
+            navigate("/login");
+          },
+        },
+      });
+    }
+  };
+}

--- a/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 
 import { EventButton, Wrapper } from "../../../../core/design_system";
+import { useCheckLogin } from "../../../../core/hooks/useCheckLogin";
 
 import { useDrawingLandingState } from "../../hooks/useDrawingLandingState";
 
@@ -8,6 +10,14 @@ import DrawingChance from "./DrawingChance";
 
 function DrawingBanner() {
   const { drawingLandingData: landData } = useDrawingLandingState();
+  const navigate = useNavigate();
+  const checkLogin = useCheckLogin();
+
+  const handleEventClick = () => {
+    checkLogin(() => {
+      navigate("/drawing/play");
+    });
+  };
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">
@@ -18,6 +28,7 @@ function DrawingBanner() {
           type="DRAWING"
           status="DEFAULT"
           content="이벤트 참여하기"
+          onClick={handleEventClick}
         />
       </BannerContentWrapper>
     </Wrapper>
@@ -29,9 +40,7 @@ export default DrawingBanner;
 const BannerContentWrapper = styled.div`
   position: absolute;
   bottom: 0;
-
   width: 100%;
-
   display: flex;
   align-items: center;
   justify-content: center;
@@ -43,9 +52,7 @@ const BannerContentWrapper = styled.div`
 
 const BannerImage = styled.img`
   position: absolute;
-
   width: 100%;
   height: 100%;
-
   object-fit: cover;
 `;

--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
@@ -1,13 +1,23 @@
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 
 import { Wrapper, EventButton } from "../../../../core/design_system";
+import { useCheckLogin } from "../../../../core/hooks/useCheckLogin";
 
 import { useQuizLandingState } from "../../hooks";
 
 import QuizBannerTimer from "./QuizBannerTimer";
 
 function QuizBanner() {
+  const navigate = useNavigate();
+  const checkLogin = useCheckLogin();
   const { quizLandingData: data } = useQuizLandingState();
+
+  const handleEventClick = () => {
+    checkLogin(() => {
+      navigate("/quiz/play");
+    });
+  };
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">
@@ -23,6 +33,7 @@ function QuizBanner() {
             type="QUIZ"
             status="DEFAULT"
             content="이벤트 참여하기"
+            onClick={handleEventClick}
           ></EventButton>
         </Wrapper>
         <QuizBannerTimer></QuizBannerTimer>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
feat/#79-link-to-event

### 💡 작업동기
- landing 페이지와 play 페이지 간의 이동을 추가합니다.

### 🔑 주요 변경사항
- useCheckLogin Hook을 만들었습니다! 로그인 유효성 검사를 해야 할 경우에 유용합니다.
```typescript
  const navigate = useNavigate();
  const checkLogin = useCheckLogin();

  const handleEventClick = () => {
    checkLogin(() => {
      navigate("/drawing/play");
    });
  };
```

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a9be61f5-f7e0-4e8e-bd9f-3c9f51c73039">


### 관련 이슈
closed: #79 
