### PR TITLE
navigate 시 스크롤 초기화 코드를 추가합니다.

### DIFF
--- a/strawberry/src/core/hooks/useScrollToTop.tsx
+++ b/strawberry/src/core/hooks/useScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+function useScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+}
+
+export default useScrollToTop;

--- a/strawberry/src/layout/DefaultLayout.tsx
+++ b/strawberry/src/layout/DefaultLayout.tsx
@@ -3,8 +3,11 @@ import Footer from "./components/footer";
 import { Outlet } from "react-router-dom";
 import { Wrapper } from "../core/design_system";
 import { Modal } from "../pages/common/components/modal/Modal";
+import useScrollToTop from "../core/hooks/useScrollToTop";
 
 function DefaultLayout() {
+  useScrollToTop();
+
   return (
     <>
       {/* LayoutWrapper */}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#97-reset-navigate-scroll

### 💡 작업동기
- 라우터의 navigate로 페이지 이동 시 스크롤이 초기화 되지 않아 해결

### 🔑 주요 변경사항
- useScrollToTop 추가
- DefaultLayout에 해당코드 추가

### 관련 이슈
- closed: #97 
