### PR TITLE
랜딩 페이지 스크롤 동작을 추가합니다.

### DIFF
--- a/strawberry/src/core/utils/index.tsx
+++ b/strawberry/src/core/utils/index.tsx
@@ -2,5 +2,6 @@ import convertSeconds from "./convertSeconds";
 import { debounce } from "./debounce";
 import { throttle } from "./throttle";
 import formatEventDateTime from "./formatEventDateTime";
+import { scrollTop } from "./scrollTop";
 
-export { convertSeconds, formatEventDateTime, debounce, throttle };
+export { convertSeconds, formatEventDateTime, debounce, throttle, scrollTop };

--- a/strawberry/src/core/utils/scrollTop.ts
+++ b/strawberry/src/core/utils/scrollTop.ts
@@ -1,0 +1,5 @@
+type ScrollTopProps = number;
+
+export function scrollTop(top: ScrollTopProps) {
+  window.scrollTo({ top: top, behavior: "smooth" });
+}

--- a/strawberry/src/pages/landing/components/landingBanner/LandingBanner.tsx
+++ b/strawberry/src/pages/landing/components/landingBanner/LandingBanner.tsx
@@ -1,22 +1,32 @@
 import styled from "styled-components";
-import { Wrapper } from "../../../../core/design_system";
-import LandingBannerBG from "/src/assets/images/temp/LandingBannerBG.svg";
+
 import LandingBannerScrollButton from "./LandingBannerScrollButton";
 
+import useLandingBanner from "../../hooks/useLandingBanner";
+
+import LandingBannerBG from "/src/assets/images/temp/LandingBannerBG.svg";
+
 function LandingBanner() {
+  const { heightRef, scrollHeight } = useLandingBanner();
+
   return (
     <>
-      <Wrapper $position="relative" width="100%">
+      <RefWrapper ref={heightRef}>
         <StyledImg src={LandingBannerBG} alt="LandingBannerBG" />
         <ScrollButtonWrapper>
-          <LandingBannerScrollButton />
+          <LandingBannerScrollButton scrollHeight={scrollHeight} />
         </ScrollButtonWrapper>
-      </Wrapper>
+      </RefWrapper>
     </>
   );
 }
 
 export default LandingBanner;
+
+const RefWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
 
 const StyledImg = styled.img`
   width: 100%;

--- a/strawberry/src/pages/landing/components/landingBanner/LandingBannerScrollButton.tsx
+++ b/strawberry/src/pages/landing/components/landingBanner/LandingBannerScrollButton.tsx
@@ -1,9 +1,17 @@
 import styled from "styled-components";
+
 import { Label, theme, Wrapper } from "../../../../core/design_system";
+import { scrollTop } from "../../../../core/utils";
 
 import arrow from "/src/assets/images/icons/Arrow_Down_L_White.svg";
 
-function LandingBannerScrollButton() {
+interface LandingBannerScrollButtonProps {
+  scrollHeight: number;
+}
+
+function LandingBannerScrollButton({
+  scrollHeight,
+}: LandingBannerScrollButtonProps) {
   return (
     <>
       <Wrapper
@@ -20,7 +28,7 @@ function LandingBannerScrollButton() {
         >
           자세한 내용은 스크롤을 내려주세요
         </Label>
-        <StyledButton>
+        <StyledButton onClick={() => scrollTop(scrollHeight)}>
           <img src={arrow} alt="arrow" />
         </StyledButton>
       </Wrapper>

--- a/strawberry/src/pages/landing/hooks/useLandingBanner.tsx
+++ b/strawberry/src/pages/landing/hooks/useLandingBanner.tsx
@@ -1,0 +1,16 @@
+import { useRef, useState, useEffect } from "react";
+
+function useLandingBanner() {
+  const heightRef = useRef<HTMLDivElement | null>(null);
+  const [scrollHeight, setScrollHeight] = useState<number>(0);
+
+  useEffect(() => {
+    if (heightRef.current) {
+      setScrollHeight(heightRef.current.offsetHeight);
+    }
+  }, [heightRef]);
+
+  return { heightRef, scrollHeight };
+}
+
+export default useLandingBanner;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#93-add-Landing-banner-scroll

### 💡 작업동기
- 랜딩페이지 스크롤 버튼에 동작을 추가합니다.

### 🔑 주요 변경사항
- scrollTop 유틸 함수 추가
- Banner에 관련 코드 추가 후 커스텀 훅으로 분리
- Button에서 height props로 받아 onClick 시 scrollTop 함수 실행 

### 관련 이슈
- closed: #93 
