### PR TITLE
퀴즈 랜딩 페이지의 참가 버튼에 게임 페이지 경로를 연결합니다. 

### DIFF
--- a/strawberry/src/data/entities/QuizLanding.tsx
+++ b/strawberry/src/data/entities/QuizLanding.tsx
@@ -18,4 +18,5 @@ export interface QuizLanding {
   startAt: string;
   endAt: string;
   winners: number;
+  subEventId: number;
 }

--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
@@ -15,7 +15,7 @@ function QuizBanner() {
 
   const handleEventClick = () => {
     checkLogin(() => {
-      navigate("/quiz/play");
+      navigate(`/quiz/play/${data?.subEventId}`);
     });
   };
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#119-quiz-event-button

### 💡 작업동기
- 현재 진행 중인 퀴즈 이벤트에 접속하기 위해 랜딩 페이지에서 받은 subEventId를 이벤트 참여 버튼에 매핑합니다.

### 🔑 주요 변경사항
- entity에 subEventId 속성 추가
- 버튼 경로 수정

### 관련 이슈
- closed: #119 
