### PR TITLE
드로잉 게임에 게임 정보 API를 연동합니다.

### DIFF
--- a/strawberry/src/core/design_system/reset.css
+++ b/strawberry/src/core/design_system/reset.css
@@ -5,7 +5,7 @@
 
 @font-face {
 	font-family: "Hyundai Sans Head KR";
-	src: url("../../assets/fonts/Hyundai_Sans_Head_KR_Regular.ttf") format("truetype");
+	src: url("/assets/fonts/Hyundai_Sans_Head_KR_Regular.ttf") format("truetype");
 }
 
 :root {

--- a/strawberry/src/data/entities/DrawingFinish.tsx
+++ b/strawberry/src/data/entities/DrawingFinish.tsx
@@ -1,0 +1,5 @@
+export interface DrawingFinish {
+  totalScore: number;
+  maxScore: number;
+  chance: number;
+}

--- a/strawberry/src/data/entities/DrawingPlay.tsx
+++ b/strawberry/src/data/entities/DrawingPlay.tsx
@@ -1,0 +1,16 @@
+interface DrawingInfo {
+  contourImgUrl: string;
+  imgUrl: string;
+  sequence: number;
+  onBoardingMsg: string;
+  gameMsg: string;
+  startPosition: {
+    x: number;
+    y: number;
+  };
+}
+
+export interface DrawingPlay {
+  gameInfos: DrawingInfo[];
+  chance: number;
+}

--- a/strawberry/src/data/entities/DrawingResult.tsx
+++ b/strawberry/src/data/entities/DrawingResult.tsx
@@ -1,0 +1,6 @@
+export interface DrawingResult {
+  score: number;
+  blurImgUrl: string;
+  resultMsg: string;
+  resultDetail: string;
+}

--- a/strawberry/src/data/queries/drawing/useDrawingFinishQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingFinishQuery.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from "react-query";
+
+import network from "../../config/network";
+
+import { DrawingFinish } from "../../entities/DrawingFinish";
+
+interface UseDrawingFinishQueryProps {
+  subEventId: number;
+}
+
+export function useDrawingFinishQuery({
+  subEventId,
+}: UseDrawingFinishQueryProps) {
+  const getDrawingFinish = async () => {
+    return network.get<DrawingFinish>("lottery/drawing/score", {
+      queryParams: {
+        subEventId,
+      },
+    });
+  };
+
+  const query = useQuery<DrawingFinish, Error>({
+    queryKey: ["drawingInfo"],
+    queryFn: getDrawingFinish,
+  });
+
+  return query;
+}

--- a/strawberry/src/data/queries/drawing/useDrawingPlayMutation.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingPlayMutation.tsx
@@ -1,0 +1,23 @@
+import { useMutation } from "react-query";
+
+import network from "../../config/network";
+
+import { DrawingResult } from "../../entities/DrawingResult";
+
+interface UseDrawingPlayMutationBody {
+  positions: { x: number; y: number }[];
+  subEventId: number;
+  sequence: number;
+}
+
+export function useDrawingPlayMutation() {
+  const postDrawingPlay = async (body: UseDrawingPlayMutationBody) => {
+    return network.post<DrawingResult>("lottery/drawing", body, {});
+  };
+
+  const mutation = useMutation({
+    mutationFn: postDrawingPlay,
+  });
+
+  return mutation;
+}

--- a/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from "react-query";
+
+import network from "../../config/network";
+
+import { DrawingPlay } from "../../entities/DrawingPlay";
+
+interface UseDrawingPlayQueryProps {
+  subEventId: number | undefined;
+  eventPlayType: "NORMAL" | "EXPECTATION" | "SHARED" | undefined;
+}
+
+export function useDrawingPlayQuery({
+  subEventId,
+  eventPlayType,
+}: UseDrawingPlayQueryProps) {
+  const getDrawingInfo = async () => {
+    return network.get<DrawingPlay>("lottery/drawing", {
+      queryParams: {
+        subEventId: subEventId,
+        eventPlayType: eventPlayType,
+      },
+    });
+  };
+
+  const query = useQuery<DrawingPlay, Error>({
+    queryKey: ["drawingInfo"],
+    queryFn: getDrawingInfo,
+  });
+
+  return query;
+}

--- a/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
@@ -14,7 +14,11 @@ import drawingFinishBG from "/src/assets/images/background/drawingFinishBG.svg";
 import useDrawingFinish from "../../hooks/useDrawingFinish.tsx";
 
 function DrawingFinish() {
-  const { finalScore, highestScore, handleSharedClick } = useDrawingFinish();
+  const gifUrl =
+    "https://s3-alpha-sig.figma.com/img/de82/685d/2752e884c15d3abd92a2193c6288551d?Expires=1724025600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=cZtbhRnyUIPmAzDki-K2F3BZTG1g2UjFubm237vFA8opEAr1ZobTFuXY14OGWp53ox3h7h1Y8HZm1qWxOeDfwvPKKFpfihaYGqUxHCB7FWvPbzyQM5SFNBJ6R3OvVkbLAKQOgiE~BcrT8yMLzGGrRiIccvJjTzuAoZWSLvMPmGKLAPptzJYypk5S2C8mDFxv04yWgjNScTR-A6CooH8-rg0MLhi6sdIpMatk-CFjzK38o3LVqxez63MBOOiK6v8r-O3XTYMsuOLs76Vzk4tLpOfmV9mWZ6jTGQZkfE43v5BqcCRo9DxsK-DdqXo7ItjQnd5Hej7622M1w0CExawoeQ__";
+
+  const { finalScore, highestScore, handleSharedClick, chance } =
+    useDrawingFinish();
 
   return (
     <>
@@ -29,7 +33,7 @@ function DrawingFinish() {
         $zindex="3"
         $position="relative"
       >
-        <HighestScore score={highestScore} />
+        <HighestScore score={Number(highestScore.toFixed(1))} />
         <Label
           $margin="40px 0 0 0"
           $token="Title2Medium"
@@ -38,9 +42,9 @@ function DrawingFinish() {
           최종 점수
         </Label>
         <Wrapper width="fit-content" height="fit-content" $position="relative">
-          <img src="https://s3-alpha-sig.figma.com/img/de82/685d/2752e884c15d3abd92a2193c6288551d?Expires=1724025600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=cZtbhRnyUIPmAzDki-K2F3BZTG1g2UjFubm237vFA8opEAr1ZobTFuXY14OGWp53ox3h7h1Y8HZm1qWxOeDfwvPKKFpfihaYGqUxHCB7FWvPbzyQM5SFNBJ6R3OvVkbLAKQOgiE~BcrT8yMLzGGrRiIccvJjTzuAoZWSLvMPmGKLAPptzJYypk5S2C8mDFxv04yWgjNScTR-A6CooH8-rg0MLhi6sdIpMatk-CFjzK38o3LVqxez63MBOOiK6v8r-O3XTYMsuOLs76Vzk4tLpOfmV9mWZ6jTGQZkfE43v5BqcCRo9DxsK-DdqXo7ItjQnd5Hej7622M1w0CExawoeQ__" />
+          <img src={gifUrl} />
           <ScoreWrapper>
-            <DrawingScore score={finalScore} />
+            <DrawingScore score={Number(finalScore.toFixed(1))} />
           </ScoreWrapper>
         </Wrapper>
         <Wrapper display="flex" $position="relative">
@@ -57,9 +61,7 @@ function DrawingFinish() {
             color={theme.Color.TextIcon.info}
             $textalign="center"
           >
-            {
-              "기회가 n번 남았어요!\n링크 공유 / 기대평 작성으로 추가 재도전 기회를 얻으세요!"
-            }
+            {`기회가 ${chance}번 남았어요!\n링크 공유 / 기대평 작성으로 추가 재도전 기회를 얻으세요!`}
           </Label>
         </Wrapper>
         <Wrapper $margin="16px 0 0 0">

--- a/strawberry/src/pages/drawingPlay/components/drawingGame/DrawingCanvas.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingGame/DrawingCanvas.tsx
@@ -72,7 +72,7 @@ const StartButton = styled.div<{ $disabled: boolean }>`
   border-radius: 12px;
   background-color: ${({ theme }) => theme.Color.TextIcon.info};
   border: none;
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? "none" : "pointer")};
   z-index: 10;
 `;
 

--- a/strawberry/src/pages/drawingPlay/components/drawingResult/DrawingResult.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingResult/DrawingResult.tsx
@@ -6,11 +6,11 @@ import {
   Wrapper,
 } from "../../../../core/design_system";
 
+import { useDrawingResult } from "../../hooks/useDrawingResult";
+
 import DrawingStep from "../DrawingStep";
 import DrawingScore from "../DrawingScore";
-
 import ImageResult from "./ImageResult";
-import { useDrawingResult } from "../../hooks/useDrawingResult";
 
 function DrawingResult() {
   const {
@@ -21,6 +21,8 @@ function DrawingResult() {
     isLastStage,
     handleNextStage,
     handleFinish,
+    score,
+    title,
   } = useDrawingResult();
 
   return (
@@ -33,14 +35,14 @@ function DrawingResult() {
           $textalign="center"
           color={theme.Color.TextIcon.default}
         >
-          조금만 더 하면 고득점!
+          {title}
         </Label>
         <Wrapper $margin="16px 0 0 0" display="flex" $justifycontent="center">
           <CanvasContainer>
             <StyledImage src={imgPath} alt="Car" />
             <ImageResult />
             <ScoreWrapper>
-              <DrawingScore score={72.2} />
+              <DrawingScore score={Number(score.toFixed(1))} />
             </ScoreWrapper>
           </CanvasContainer>
         </Wrapper>

--- a/strawberry/src/pages/drawingPlay/contexts/drawingPlayContext.tsx
+++ b/strawberry/src/pages/drawingPlay/contexts/drawingPlayContext.tsx
@@ -12,6 +12,8 @@ const initialState: DrawingPlayState = {
   canvasImg: "",
   timeLimit: 7,
   isDrawing: false,
+  drawingInfo: undefined,
+  drawingResult: undefined,
 };
 
 // 리듀서 함수
@@ -42,6 +44,10 @@ const drawingPlayReducer = (
       return { ...state, isDrawing: true };
     case "SET_FINISH_DRAWING":
       return { ...state, isDrawing: false };
+    case "SET_DRAWING_INFO":
+      return { ...state, drawingInfo: action.payload };
+    case "SET_DRAWING_RESULT":
+      return { ...state, drawingResult: action.payload };
     default:
       return state;
   }

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
@@ -1,21 +1,15 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 
 import { useDrawingSharedQuery } from "../../../data/queries/drawing/useDrawingSharedQuery";
+import { useDrawingFinishQuery } from "../../../data/queries/drawing/useDrawingFinishQuery";
 
 function useDrawingFinish() {
-  const [finalScore, setFinalScore] = useState<number>(0);
-  const [highestScore, setHighestScore] = useState<number>(0);
+  const { data: drawingFinish } = useDrawingFinishQuery({ subEventId: 4 });
 
   const { data: sharedData, refetch: getSharedData } = useDrawingSharedQuery({
     // 컨텍스트 값으로 대체
     subEventId: 4,
   });
-
-  useEffect(() => {
-    // 서버 요청
-    setFinalScore(72);
-    setHighestScore(100);
-  }, []);
 
   useEffect(() => {
     if (sharedData?.sharedUrl) {
@@ -28,8 +22,9 @@ function useDrawingFinish() {
   };
 
   return {
-    finalScore,
-    highestScore,
+    finalScore: drawingFinish?.totalScore ?? 0,
+    highestScore: drawingFinish?.maxScore ?? 0,
+    chance: drawingFinish?.chance ?? 0,
     handleSharedClick,
   };
 }

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingOnboarding.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingOnboarding.tsx
@@ -3,22 +3,18 @@ import { useEffect } from "react";
 import { useDrawingPlayDispatch } from "./useDrawingPlayDispatch";
 import { useDrawingPlayState } from "./useDrawingPlayState";
 
-import santafeBG from "/src/assets/images/background/santafeBG.png";
-import interiorBG from "/src/assets/images/background/interiorBG.png";
-import exteriorBG from "/src/assets/images/background/exteriorBG.png";
-
 export function useDrawingOnboarding() {
-  const { stage, totalStage, isGuideOpen } = useDrawingPlayState();
+  const { stage, totalStage, isGuideOpen, drawingInfo } = useDrawingPlayState();
   const dispatch = useDrawingPlayDispatch();
 
   useEffect(() => {
     if (!localStorage.getItem("hideGuideModalUntil") && isGuideOpen !== false) {
       dispatch({ type: "SET_GUIDE_OPEN", payload: true });
     }
-  }, []);
+  }, [isGuideOpen, dispatch]);
 
   useEffect(() => {
-    if (isGuideOpen === false) {
+    if (localStorage.getItem("hideGuideModalUntil") || isGuideOpen === false) {
       const id = setTimeout(() => {
         dispatch({ type: "SET_GAME" });
       }, 3000);
@@ -30,16 +26,8 @@ export function useDrawingOnboarding() {
   return {
     stage,
     totalStage,
-    imgPath: imgPaths[stage],
-    title: titles[stage],
+    imgPath: drawingInfo?.gameInfos?.[stage - 1].imgUrl ?? "",
+    title: drawingInfo?.gameInfos?.[stage - 1].onBoardingMsg ?? "",
     isGuideOpen,
   };
 }
-
-const imgPaths = ["", santafeBG, interiorBG, exteriorBG];
-const titles = [
-  "",
-  "3초 후 디 올 뉴 싼타페를 그려주세요!",
-  "3초 후 디 올 뉴 싼타페의 space를 그려주세요!",
-  "3초 후 디 올 뉴 싼타페의 space를 그려주세요!",
-];

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingPlayPage.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingPlayPage.tsx
@@ -5,11 +5,29 @@ import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
 import useNavigationBlocker from "../../common/hooks/useNavigationBlock";
 
 import { useDrawingPlayState } from "./useDrawingPlayState";
+import { useDrawingPlayDispatch } from "./useDrawingPlayDispatch";
+import { useDrawingPlayQuery } from "../../../data/queries/drawing/useDrawingPlayQuery";
 
 function useDrawingPlayPage() {
   const { status } = useDrawingPlayState();
   const { isBlocked, proceed, reset } = useNavigationBlocker();
+
+  const drawingPlayDispatch = useDrawingPlayDispatch();
   const dispatch = useGlobalDispatch();
+
+  const { data: drawingInfo } = useDrawingPlayQuery({
+    subEventId: 4,
+    eventPlayType: "NORMAL",
+  });
+
+  useEffect(() => {
+    if (drawingInfo) {
+      drawingPlayDispatch({
+        type: "SET_DRAWING_INFO",
+        payload: drawingInfo,
+      });
+    }
+  }, [drawingInfo]);
 
   useEffect(() => {
     if (isBlocked && status !== "finish") {

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingResult.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingResult.tsx
@@ -1,13 +1,9 @@
 import { useDrawingPlayDispatch } from "./useDrawingPlayDispatch";
 import { useDrawingPlayState } from "./useDrawingPlayState";
 
-import santafeBlurBG from "/src/assets/images/background/santafeBlurBG.png";
-import interiorBlurBG from "/src/assets/images/background/interiorBlurBG.png";
-import exteriorBlurBG from "/src/assets/images/background/exteriorBlurBG.png";
-
 export function useDrawingResult() {
   const dispatch = useDrawingPlayDispatch();
-  const { stage, totalStage, canvasImg } = useDrawingPlayState();
+  const { stage, totalStage, canvasImg, drawingResult } = useDrawingPlayState();
 
   const handleNextStage = () => {
     dispatch({ type: "SET_ON_BOARDING" });
@@ -22,19 +18,12 @@ export function useDrawingResult() {
     stage,
     totalStage,
     canvasImg,
-    description: descriptions[stage],
-    imgPath: imgPaths[stage],
+    description: drawingResult?.resultDetail ?? "",
+    imgPath: drawingResult?.blurImgUrl ?? "",
+    title: drawingResult?.resultMsg,
     isLastStage: stage === totalStage,
     handleNextStage,
     handleFinish,
+    score: drawingResult?.score ?? 0,
   };
 }
-
-const descriptions = [
-  "",
-  "디 올 뉴 싼타페의 실내는 언제 어디서든 아웃도어 라이프를 즐길 수 있는 넉넉한 거주 공간을 자랑하며\n수평과 수직 이미지를 강조한 레이아웃으로 외장과 자연스럽게 어우러질 수 있도록 디자인했습니다.",
-  "디 올 뉴 싼타페는 평평하게 폴딩이 가능한 2/3열 시트와 넓은 테일게이트 구성으로\n가장 실용적인 SUV로 나아가고 있습니다.",
-  "디 올 뉴 싼타페는 테라스 컨셉의 테일게이트 공간을 기반으로 적재 이용성은 물론\n대형 테일게이트의 개방감을 활용한 다양한 아웃도어 활동을 지원합니다. ",
-];
-
-const imgPaths = ["", santafeBlurBG, interiorBlurBG, exteriorBlurBG];

--- a/strawberry/src/pages/drawingPlay/models/DrawingPlayAction.tsx
+++ b/strawberry/src/pages/drawingPlay/models/DrawingPlayAction.tsx
@@ -1,3 +1,6 @@
+import { DrawingPlay } from "../../../data/entities/DrawingPlay";
+import { DrawingResult } from "../../../data/entities/DrawingResult";
+
 export type DrawingPlayAction =
   | { type: "SET_GUIDE_OPEN"; payload: boolean }
   | { type: "SET_GUIDE_INDEX"; payload: number }
@@ -9,4 +12,6 @@ export type DrawingPlayAction =
   | { type: "SET_FINISH" }
   | { type: "SET_CANVAS_IMG"; payload: string }
   | { type: "SET_START_DRAWING" }
-  | { type: "SET_FINISH_DRAWING" };
+  | { type: "SET_FINISH_DRAWING" }
+  | { type: "SET_DRAWING_INFO"; payload: DrawingPlay }
+  | { type: "SET_DRAWING_RESULT"; payload: DrawingResult };

--- a/strawberry/src/pages/drawingPlay/models/DrawingPlayState.tsx
+++ b/strawberry/src/pages/drawingPlay/models/DrawingPlayState.tsx
@@ -1,3 +1,6 @@
+import { DrawingPlay } from "../../../data/entities/DrawingPlay";
+import { DrawingResult } from "../../../data/entities/DrawingResult";
+
 type StageType = 1 | 2 | 3 | number;
 type StatusType = "onBoarding" | "game" | "result" | "finish";
 
@@ -10,6 +13,8 @@ export interface DrawingPlayState {
   canvasImg: string;
   timeLimit: number;
   isDrawing: boolean;
+  drawingInfo: DrawingPlay | undefined;
+  drawingResult: DrawingResult | undefined;
 }
 
 export default DrawingPlayState;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#121-add-drawing-play-api

### 💡 작업동기
- 드로잉 게임에 관한 모든 정보를 서버에서 받아옵니다.

### 🔑 주요 변경사항
- 쿼리, 뮤테이션 추가
- entity 추가
- OnBoarding, Game, Result, Finish에 서버 정보 반영
- 모달 로직 수정
- font path 수정

### 관련 이슈
- closed: #121 
