### PR TITLE
퀴즈 플레이 시 엔터로 답안을 제출하고, 오답 모달을 닫고 인풋에 포커스 되도록 합니다.

### DIFF
--- a/strawberry/src/pages/quizPlay/QuizPlayPage.tsx
+++ b/strawberry/src/pages/quizPlay/QuizPlayPage.tsx
@@ -48,7 +48,11 @@ function QuizPlayPage() {
         <Label $token="Title1Medium" $margin="0 40px 0 0">
           정답 :
         </Label>
-        <CardInput placeholder={placeholder} length={placeholder?.length} />
+        <CardInput
+          placeholder={placeholder}
+          length={placeholder?.length}
+          handleSubmit={handleSubmit}
+        />
       </Wrapper>
       <Wrapper
         $margin="70px 0 0 0"

--- a/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
+++ b/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
@@ -1,19 +1,22 @@
 import React, { useRef, useEffect } from "react";
 import styled from "styled-components";
 
+import { useGlobalState } from "../../../../core/hooks/useGlobalState";
 import { useQuizPlayState } from "../../hooks/useQuizPlayState";
 import { useQuizPlayDispatch } from "../../hooks/useQuizPlayDispatch";
 
 interface CardInputProps {
   length: number;
   placeholder: string;
+  handleSubmit: () => void;
 }
 
 const CardInput = (props: CardInputProps) => {
-  const { length, placeholder } = props;
+  const { length, placeholder, handleSubmit } = props;
 
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const { isModalOpen } = useGlobalState();
   const { answer: content } = useQuizPlayState();
   const dispatch = useQuizPlayDispatch();
 
@@ -22,6 +25,12 @@ const CardInput = (props: CardInputProps) => {
       inputRef.current.focus();
     }
   }, []);
+
+  useEffect(() => {
+    if (!isModalOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isModalOpen]);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -33,6 +42,12 @@ const CardInput = (props: CardInputProps) => {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
       event.preventDefault();
+    }
+
+    if (event.key === "Enter") {
+      if (content.length === length) {
+        handleSubmit();
+      }
     }
   };
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#149-enter-answer

### 💡 작업동기
- UX 향상을 위해 엔터 답안 제출, 오답 모달 이후 포커스 기능을 추가

### 🔑 주요 변경사항
- input에 enter를 감지하는 keyDown 이벤트 추가
- input에 isModalOpen 기반의 focus 코드를 추가

### 관련 이슈
- closed: #149 
