### PR TITLE
드로잉 게임 progressbar 로직을 수정합니다.

### DIFF
--- a/strawberry/src/pages/drawingPlay/components/drawingOnboarding/DrawingOnboarding.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingOnboarding/DrawingOnboarding.tsx
@@ -11,6 +11,11 @@ function DrawingOnboarding() {
   const { stage, totalStage, imgPath, title, isGuideOpen } =
     useDrawingOnboarding();
 
+  // 모달이 닫히거나, 모달 보지않기 옵션이 켜져있을 때(없는 키를 getItem 하면 null)
+  const isStarted =
+    isGuideOpen === false ||
+    localStorage.getItem("hideGuideModalUntil") !== null;
+
   return (
     <>
       {isGuideOpen && <DrawingGuideModal />}
@@ -30,7 +35,7 @@ function DrawingOnboarding() {
           </CanvasContainer>
         </Wrapper>
         <Wrapper $margin="30px 0 0 0">
-          <ProgressBar timeLimit={3} isProgress={isGuideOpen === false} />
+          <ProgressBar timeLimit={3} isProgress={isStarted} />
         </Wrapper>
       </GameWrapper>
     </>

--- a/strawberry/src/pages/drawingPlay/components/drawingOnboarding/DrawingOnboarding.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingOnboarding/DrawingOnboarding.tsx
@@ -30,7 +30,7 @@ function DrawingOnboarding() {
           </CanvasContainer>
         </Wrapper>
         <Wrapper $margin="30px 0 0 0">
-          <ProgressBar timeLimit={3} isProgress={!isGuideOpen} />
+          <ProgressBar timeLimit={3} isProgress={isGuideOpen === false} />
         </Wrapper>
       </GameWrapper>
     </>

--- a/strawberry/src/pages/drawingPlay/hooks/useProgressBar.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useProgressBar.tsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from "react";
+import { useDrawingPlayState } from "./useDrawingPlayState";
 
 function useProgressBar(timeLimit: number, isProgress: boolean) {
   const [progress, setProgress] = useState(0);
   const [timer, setTimer] = useState(timeLimit);
+
+  const { status, isGuideOpen, isDrawing } = useDrawingPlayState();
 
   const updateProgress = () => {
     setProgress((prev) => {
@@ -12,7 +15,11 @@ function useProgressBar(timeLimit: number, isProgress: boolean) {
   };
 
   useEffect(() => {
-    if (isProgress) {
+    if (
+      (status === "onBoarding" &&
+        localStorage.getItem("hideGuideModalUntil")) ||
+      isProgress
+    ) {
       setProgress(0);
       setTimer(timeLimit);
 
@@ -32,7 +39,7 @@ function useProgressBar(timeLimit: number, isProgress: boolean) {
 
       return () => clearInterval(interval);
     }
-  }, [isProgress, timeLimit]);
+  }, [isProgress, timeLimit, isDrawing]);
 
   return { progress, timer };
 }

--- a/strawberry/src/pages/drawingPlay/hooks/useProgressBar.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useProgressBar.tsx
@@ -1,11 +1,8 @@
 import { useState, useEffect } from "react";
-import { useDrawingPlayState } from "./useDrawingPlayState";
 
 function useProgressBar(timeLimit: number, isProgress: boolean) {
   const [progress, setProgress] = useState(0);
   const [timer, setTimer] = useState(timeLimit);
-
-  const { status, isGuideOpen, isDrawing } = useDrawingPlayState();
 
   const updateProgress = () => {
     setProgress((prev) => {
@@ -15,11 +12,7 @@ function useProgressBar(timeLimit: number, isProgress: boolean) {
   };
 
   useEffect(() => {
-    if (
-      (status === "onBoarding" &&
-        localStorage.getItem("hideGuideModalUntil")) ||
-      isProgress
-    ) {
+    if (isProgress) {
       setProgress(0);
       setTimer(timeLimit);
 
@@ -39,7 +32,7 @@ function useProgressBar(timeLimit: number, isProgress: boolean) {
 
       return () => clearInterval(interval);
     }
-  }, [isProgress, timeLimit, isDrawing]);
+  }, [isProgress, timeLimit]);
 
   return { progress, timer };
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#124-modify-progress-logic

### 💡 작업동기
- 모달이 띄워진 상태에서 프로그래스바가 1초부터 시작하는 현상이 발생하여 해결

### 🔑 주요 변경사항
- 로직 변경

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/55132a49-4440-4d92-b12f-19ef2a02d45a">

### 관련 이슈
- closed: #124 
