### PR TITLE
신차 소개 페이지의 버튼을 포함하는 bottom 컴포넌트를 구현합니다. 

### DIFF
--- a/strawberry/src/pages/newCar/components/newCarBottom/NewCarBottom.tsx
+++ b/strawberry/src/pages/newCar/components/newCarBottom/NewCarBottom.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import { Label, theme } from "../../../../core/design_system";
+import { Link } from "react-router-dom";
+
+function NewCarBottom() {
+  return (
+    <NewCarBottomWrapper>
+      <StyledButton
+        as={Link}
+        to="https://www.hyundai.com/kr/ko/e/vehicles/the-all-new-santafe/intro"
+      >
+        <Label $token="Heading2Regular" color={theme.Color.TextIcon.reverse}>
+          디 올 뉴 싼타페 자세히 보기
+        </Label>
+      </StyledButton>
+    </NewCarBottomWrapper>
+  );
+}
+
+export default NewCarBottom;
+
+const NewCarBottomWrapper = styled.div`
+  height: 246px;
+  background: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledButton = styled.button`
+  display: flex;
+  width: 400px;
+  padding: 12px 28px;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.Color.Primary.normal};
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+`;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#155-implement-NewCar-Bottom

### 💡 작업동기
- 신차 소개 페이지에서 사용하는 Bottom 컴포넌트 구현

### 🔑 주요 변경사항
- 컴포넌트 구현

### 🏞 스크린샷
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/6c3f73fe-462b-45dc-8292-21eaf2894124">

### 관련 이슈
- closed: #155 
