### PR TITLE
헤더의 버튼 width, height를 제거합니다.

### DIFF
--- a/strawberry/src/layout/components/header/CarIntroButton.tsx
+++ b/strawberry/src/layout/components/header/CarIntroButton.tsx
@@ -21,5 +21,4 @@ const StyledButton = styled(DefaultButton)`
   color: ${({ theme }) => theme.Color.TextIcon.sub};
   padding: 8px 20px;
   width: fit-content;
-  height: 40px;
 `;

--- a/strawberry/src/layout/components/header/Header.tsx
+++ b/strawberry/src/layout/components/header/Header.tsx
@@ -15,7 +15,7 @@ function Header() {
       <HeaderWrapper>
         <HeaderLogo></HeaderLogo>
         <nav>
-          <HeaderMenuButtons></HeaderMenuButtons>
+          <HeaderMenuButtons />
         </nav>
         <ButtonWrapper>
           {!isLogin && <LoginButton />}
@@ -46,7 +46,7 @@ const HeaderWrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
-  width: 277px;
+  gap: 8px;
   height: 100%;
   display: flex;
   margin-left: 70px;

--- a/strawberry/src/layout/components/header/LoginButton.tsx
+++ b/strawberry/src/layout/components/header/LoginButton.tsx
@@ -19,6 +19,4 @@ const StyledButton = styled(DefaultButton)`
   font-size: ${({ theme }) => theme.Typography.Body1Regular};
   color: ${({ theme }) => theme.Color.TextIcon.reverse};
   padding: 8px 20px;
-  width: 81px;
-  height: 40px;
 `;

--- a/strawberry/src/layout/components/header/LogoutButton.tsx
+++ b/strawberry/src/layout/components/header/LogoutButton.tsx
@@ -20,7 +20,5 @@ const StyledButton = styled(DefaultButton)`
   ${({ theme }) => theme.Typography.Body1Regular};
   color: ${({ theme }) => theme.Color.TextIcon.default};
   padding: 8px 20px;
-  width: 81px;
-  height: 40px;
   white-space: nowrap;
 `;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- design-#158-header-button-css

### 💡 작업동기
- 화면 크기가 달라질 때를 위해 버튼의 크기를 padding으로만 조절

### 🔑 주요 변경사항
- width, height 제거
- 버튼 간격 gap으로 조절

### 관련 이슈
- closed: #158 
