### PR TITLE
OneButtonModal에 Enter로 close할 수 있는 기능을 추가합니다.

### DIFF
--- a/strawberry/src/core/contexts/globalContext.tsx
+++ b/strawberry/src/core/contexts/globalContext.tsx
@@ -22,6 +22,7 @@ type ModalPropsType = {
   primaryBtnContent?: string;
   onWhiteBtnClick?: () => void;
   onPrimaryBtnClick?: () => void;
+  enter?: boolean;
 } | null;
 
 // Global State Types

--- a/strawberry/src/pages/common/components/modal/OneButtonModal.tsx
+++ b/strawberry/src/pages/common/components/modal/OneButtonModal.tsx
@@ -1,7 +1,10 @@
-import ModalButton from "../buttons/ModalButton";
+import { useEffect } from "react";
+
 import { theme, Label, Wrapper } from "../../../../core/design_system";
 import { useGlobalState } from "../../../../core/hooks/useGlobalState";
 import { useGlobalDispatch } from "../../../../core/hooks/useGlobalDispatch";
+
+import ModalButton from "../buttons/ModalButton";
 
 function OneButtonModal() {
   const globalDispatch = useGlobalDispatch();
@@ -10,8 +13,23 @@ function OneButtonModal() {
     globalDispatch?.({ type: "CLOSE_MODAL" });
   }
 
-  const { title, imgPath, info, primaryBtnContent, onPrimaryBtnClick } =
+  const { title, imgPath, info, primaryBtnContent, onPrimaryBtnClick, enter } =
     useGlobalState().modalProps || {};
+
+  useEffect(() => {
+    if (enter) {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Enter" && onPrimaryBtnClick) {
+          onPrimaryBtnClick();
+        }
+      };
+
+      window.addEventListener("keydown", handleKeyDown);
+      return () => {
+        window.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [enter]);
 
   return (
     <>

--- a/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
+++ b/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
@@ -46,6 +46,7 @@ const CardInput = (props: CardInputProps) => {
 
     if (event.key === "Enter") {
       if (content.length === length) {
+        inputRef.current?.blur();
         handleSubmit();
       }
     }
@@ -93,7 +94,6 @@ const CardInput = (props: CardInputProps) => {
 
 export default CardInput;
 
-// Styled Components
 const Container = styled.div<{ length: number }>`
   width: ${({ length }) => 143 * length + 25 * (length - 1)}px;
   height: 143px;

--- a/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
+++ b/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
@@ -44,11 +44,9 @@ const CardInput = (props: CardInputProps) => {
       event.preventDefault();
     }
 
-    if (event.key === "Enter") {
-      if (content.length === length) {
-        inputRef.current?.blur();
-        handleSubmit();
-      }
+    if (event.key === "Enter" && content.length === length) {
+      inputRef.current?.blur();
+      handleSubmit();
     }
   };
 

--- a/strawberry/src/pages/quizPlay/hooks/usePrizeModal.tsx
+++ b/strawberry/src/pages/quizPlay/hooks/usePrizeModal.tsx
@@ -1,5 +1,6 @@
-import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
 import { useNavigate } from "react-router-dom";
+
+import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
 
 interface OpenModalProps {
   isCorrect: boolean;
@@ -19,6 +20,7 @@ function usePrizeModal() {
       onPrimaryBtnClick: () => {
         globalDispatch?.({ type: "CLOSE_MODAL" });
       },
+      enter: true,
     },
     correctButNotWinner: {
       title: "아쉽게도 순위에 들지 못했어요 😔",
@@ -28,6 +30,7 @@ function usePrizeModal() {
         globalDispatch?.({ type: "CLOSE_MODAL" });
         navigate("/quiz");
       },
+      enter: true,
     },
     winner: (prizeImgUrl: string) => ({
       title: "축하합니다!",
@@ -38,6 +41,7 @@ function usePrizeModal() {
         globalDispatch?.({ type: "CLOSE_MODAL" });
         navigate("/drawing");
       },
+      enter: true,
     }),
   };
 

--- a/strawberry/src/pages/quizPlay/hooks/usePrizeModal.tsx
+++ b/strawberry/src/pages/quizPlay/hooks/usePrizeModal.tsx
@@ -30,7 +30,6 @@ function usePrizeModal() {
         globalDispatch?.({ type: "CLOSE_MODAL" });
         navigate("/quiz");
       },
-      enter: true,
     },
     winner: (prizeImgUrl: string) => ({
       title: "축하합니다!",
@@ -41,7 +40,6 @@ function usePrizeModal() {
         globalDispatch?.({ type: "CLOSE_MODAL" });
         navigate("/drawing");
       },
-      enter: true,
     }),
   };
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#152-OneButtonModal-close

### 💡 작업동기
- 퀴즈 이벤트 진행 시 OneButtonModal에서 버튼 클릭 대신 enter로 대체할 수 있도록 기능 추가

### 🔑 주요 변경사항
- globalContext에 enter property 추가
- usePrizeModal에 enter 속성 추가

(OneButtonModal은 버튼이 한 개이므로 따로 엔터 callback을 넣어주지 않고, onClick 이벤트가 실행되도록 처리했습니다.)

### 관련 이슈
- closed: #152 
