### PR TITLE
드로잉 결과 페이지의 디테일 사항을 추가합니다.

### DIFF
--- a/strawberry/public/assets/icons/retry_disabled.svg
+++ b/strawberry/public/assets/icons/retry_disabled.svg
@@ -1,0 +1,18 @@
+<svg width="122" height="122" viewBox="0 0 122 122" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_2373_8163)">
+<circle cx="61" cy="61" r="45" fill="#C2C4C8"/>
+</g>
+<path d="M61.0007 48.5007V54.7507L69.334 46.4173L61.0007 38.084V44.334C51.7923 44.334 44.334 51.7923 44.334 61.0007C44.334 64.2715 45.2923 67.3132 46.9173 69.8757L49.959 66.834C49.0215 65.1048 48.5007 63.1048 48.5007 61.0007C48.5007 54.1048 54.1048 48.5007 61.0007 48.5007ZM75.084 52.1257L72.0423 55.1673C72.959 56.9173 73.5007 58.8965 73.5007 61.0007C73.5007 67.8965 67.8965 73.5006 61.0007 73.5006V67.2507L52.6673 75.584L61.0007 83.9173V77.6673C70.209 77.6673 77.6673 70.209 77.6673 61.0007C77.6673 57.7298 76.709 54.6882 75.084 52.1257Z" fill="white"/>
+<defs>
+<filter id="filter0_d_2373_8163" x="0" y="0" width="122" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="8"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2373_8163"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2373_8163" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/strawberry/src/core/design_system/ImageEnum.ts
+++ b/strawberry/src/core/design_system/ImageEnum.ts
@@ -27,6 +27,7 @@ export const ImageEnum = {
     POPOVER: "/assets/icons/popover.svg",
     POPOVERBUTTON: "/assets/icons/popoverButton.svg",
     RETRYBUTTON: "/assets/icons/retryButton.svg",
+    RETRY_DISABLED: "/assets/icons/retry_disabled.svg",
     SILVERRANKBADGE: "/assets/icons/silverRankBadge.svg",
     UPPERRIGHTBUTTON: "/assets/icons/upperRightButton.svg",
     URLBUTTON: "/assets/icons/urlButton.svg",

--- a/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
@@ -25,6 +25,11 @@ export function useDrawingPlayQuery({
   const query = useQuery<DrawingPlay, Error>({
     queryKey: ["drawingInfo"],
     queryFn: getDrawingInfo,
+    retry: 0,
+    onError: () => {
+      alert("잘못된 접근입니다.");
+      location.href = `${window.location.origin}/drawing`;
+    },
   });
 
   return query;

--- a/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
@@ -26,6 +26,7 @@ export function useDrawingPlayQuery({
     queryKey: ["drawingInfo"],
     queryFn: getDrawingInfo,
     retry: 0,
+    refetchOnWindowFocus: false,
     onError: () => {
       alert("잘못된 접근입니다.");
       location.href = `${window.location.origin}/drawing`;

--- a/strawberry/src/data/queries/drawing/useDrawingSharedQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingSharedQuery.tsx
@@ -20,6 +20,7 @@ export function useDrawingSharedQuery({
     queryKey: ["drawingShared"],
     queryFn: getDrawingShared,
     enabled: false,
+    staleTime: 4000,
   });
 
   return query;

--- a/strawberry/src/data/queries/expectation/useExpectationMutation.tsx
+++ b/strawberry/src/data/queries/expectation/useExpectationMutation.tsx
@@ -13,7 +13,6 @@ export function useExpectationMutation() {
 
   const mutation = useMutation({
     mutationFn: postExpectation,
-    onSuccess: () => location.reload(),
   });
 
   return mutation;

--- a/strawberry/src/pages/common/hooks/useToast.tsx
+++ b/strawberry/src/pages/common/hooks/useToast.tsx
@@ -13,11 +13,11 @@ function useToast() {
     let closeTimeout: number;
 
     if (isToastOpen) {
-      hideTimeout = window.setTimeout(() => {
+      hideTimeout = setTimeout(() => {
         setIsVisible(false);
       }, 2000);
 
-      closeTimeout = window.setTimeout(() => {
+      closeTimeout = setTimeout(() => {
         globalDispatch({ type: "CLOSE_TOAST" });
         setIsVisible(true);
       }, 4000);

--- a/strawberry/src/pages/common/hooks/useToast.tsx
+++ b/strawberry/src/pages/common/hooks/useToast.tsx
@@ -9,15 +9,28 @@ function useToast() {
   const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
+    let hideTimeout: number;
+    let closeTimeout: number;
+
     if (isToastOpen) {
-      setTimeout(() => {
+      hideTimeout = window.setTimeout(() => {
         setIsVisible(false);
       }, 2000);
 
-      setTimeout(() => {
+      closeTimeout = window.setTimeout(() => {
         globalDispatch({ type: "CLOSE_TOAST" });
+        setIsVisible(true);
       }, 4000);
     }
+
+    return () => {
+      if (hideTimeout) {
+        clearTimeout(hideTimeout);
+      }
+      if (closeTimeout) {
+        clearTimeout(closeTimeout);
+      }
+    };
   }, [isToastOpen, globalDispatch]);
 
   return {

--- a/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
@@ -19,8 +19,13 @@ function DrawingFinish() {
   const gifUrl =
     "https://s3-alpha-sig.figma.com/img/de82/685d/2752e884c15d3abd92a2193c6288551d?Expires=1724025600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=cZtbhRnyUIPmAzDki-K2F3BZTG1g2UjFubm237vFA8opEAr1ZobTFuXY14OGWp53ox3h7h1Y8HZm1qWxOeDfwvPKKFpfihaYGqUxHCB7FWvPbzyQM5SFNBJ6R3OvVkbLAKQOgiE~BcrT8yMLzGGrRiIccvJjTzuAoZWSLvMPmGKLAPptzJYypk5S2C8mDFxv04yWgjNScTR-A6CooH8-rg0MLhi6sdIpMatk-CFjzK38o3LVqxez63MBOOiK6v8r-O3XTYMsuOLs76Vzk4tLpOfmV9mWZ6jTGQZkfE43v5BqcCRo9DxsK-DdqXo7ItjQnd5Hej7622M1w0CExawoeQ__";
 
-  const { finalScore, highestScore, handleSharedClick, chance } =
-    useDrawingFinish();
+  const {
+    finalScore,
+    highestScore,
+    handleSharedClick,
+    chance,
+    handleRetryClick,
+  } = useDrawingFinish();
 
   return (
     <>
@@ -81,10 +86,32 @@ function DrawingFinish() {
               URL 복사하기
             </Label>
           </StyledButton>
-          <StyledButton>
-            <img src={ImageEnum.ICONS.RETRYBUTTON} alt="url" width="100px" />
-            <Label $token="Heading1Regular">게임 다시하기</Label>
-          </StyledButton>
+
+          {chance > 0 ? (
+            <RetryDefaultButton onClick={handleRetryClick}>
+              <img src={ImageEnum.ICONS.RETRYBUTTON} alt="url" width="100px" />
+              <Label
+                $token="Heading1Regular"
+                color={theme.Color.TextIcon.default}
+              >
+                게임 다시하기
+              </Label>
+            </RetryDefaultButton>
+          ) : (
+            <RetryDisabledButton>
+              <img
+                src={ImageEnum.ICONS.RETRY_DISABLED}
+                alt="url"
+                width="100px"
+              />
+              <Label
+                $token="Heading1Regular"
+                color={theme.Color.TextIcon.assistive}
+              >
+                게임 다시하기
+              </Label>
+            </RetryDisabledButton>
+          )}
         </Wrapper>
       </Wrapper>
     </>
@@ -107,6 +134,19 @@ const ScoreWrapper = styled.div`
   transform: translate(-50%, -50%);
 `;
 
+const RetryDefaultButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+const RetryDisabledButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  cursor: default;
+`;
 const StyledButton = styled.button`
   display: flex;
   flex-direction: column;

--- a/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingInput.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingInput.tsx
@@ -4,14 +4,27 @@ import { Wrapper } from "../../../../core/design_system";
 
 import useLengthValidation from "../../../expectation/hooks/useLengthValidation";
 
+import { useExpectationMutation } from "../../../../data/queries";
+import { useGlobalDispatch } from "../../../../core/hooks/useGlobalDispatch";
+import { useState } from "react";
+
 function DrawingInput() {
+  const globalDispatch = useGlobalDispatch();
+  const { mutate: postExpectation } = useExpectationMutation();
+  const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
+
   const { content, handleChange } = useLengthValidation({
     initialContent: "",
     maxLength: 300,
   });
 
   function handleClick() {
-    // 제출
+    postExpectation({ comment: content });
+    globalDispatch({
+      type: "OPEN_TOAST",
+      toastContent: "기대평이 등록되었습니다",
+    });
+    setIsSubmitted(true);
   }
 
   return (
@@ -26,7 +39,9 @@ function DrawingInput() {
         value={content}
         onChange={handleChange}
       />
-      <StyledButton onClick={handleClick}>등록</StyledButton>
+      <StyledButton disabled={isSubmitted} onClick={handleClick}>
+        등록
+      </StyledButton>
     </Wrapper>
   );
 }
@@ -55,9 +70,12 @@ const StyledInput = styled.textarea`
 const StyledButton = styled.button`
   height: 100%;
   padding: 12px 32.5px;
-  background-color: ${({ theme }) => theme.Color.Primary.normal};
-  color: ${({ theme }) => theme.Color.TextIcon.reverse};
+  background-color: ${({ theme, disabled }) =>
+    disabled ? theme.Color.TextIcon.disable : theme.Color.Primary.normal};
+  color: ${({ theme, disabled }) =>
+    disabled ? theme.Color.TextIcon.info : theme.Color.TextIcon.reverse};
   box-sizing: border-box;
-  ${({ theme }) => theme.Typography.Body1Regular}
+  ${({ theme }) => theme.Typography.Body1Regular};
   white-space: nowrap;
+  cursor: ${({ disabled }) => (disabled ? "default" : "cursor")};
 `;

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingCanvas.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingCanvas.tsx
@@ -66,7 +66,7 @@ export function useDrawingCanvas(timeLimit = 10) {
     userPointsRef.current = [];
     setTimer(timeLimit);
 
-    intervalRef.current = window.setInterval(() => {
+    intervalRef.current = setInterval(() => {
       setTimer((prev) => {
         if (prev === 1) {
           clearInterval(intervalRef.current as number);

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
@@ -27,11 +27,16 @@ function useDrawingFinish() {
     getSharedData();
   };
 
+  const handleRetryClick = () => {
+    location.reload();
+  };
+
   return {
     finalScore: drawingFinish?.totalScore ?? 0,
     highestScore: drawingFinish?.maxScore ?? 0,
     chance: drawingFinish?.chance ?? 0,
     handleSharedClick,
+    handleRetryClick,
   };
 }
 

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
@@ -7,24 +7,37 @@ import { useDrawingFinishQuery } from "../../../data/queries/drawing/useDrawingF
 
 function useDrawingFinish() {
   const globalDispatch = useGlobalDispatch();
-  const { data: drawingFinish } = useDrawingFinishQuery({ subEventId: 4 });
-  const { data: sharedData, refetch: getSharedData } = useDrawingSharedQuery({
+  const { data: drawingFinish } = useDrawingFinishQuery({
+    subEventId: 4,
+  });
+  const {
+    data: sharedData,
+    refetch: getSharedData,
+    isStale,
+  } = useDrawingSharedQuery({
     // 컨텍스트 값으로 대체
     subEventId: 4,
   });
 
   useEffect(() => {
-    if (sharedData?.sharedUrl) {
+    if (sharedData?.sharedUrl && !isStale) {
       navigator.clipboard.writeText(sharedData.sharedUrl);
       globalDispatch({
-        type: "OPEN_TOAST",
-        toastContent: "내 점수와 url이 복사되었습니다",
+        type: "CLOSE_TOAST",
       });
+      setTimeout(() => {
+        globalDispatch({
+          type: "OPEN_TOAST",
+          toastContent: "내 점수와 url이 복사되었습니다",
+        });
+      }, 1);
     }
-  }, [sharedData?.sharedUrl]);
+  }, [isStale, sharedData?.sharedUrl, globalDispatch]);
 
   const handleSharedClick = () => {
-    getSharedData();
+    if (isStale) {
+      getSharedData();
+    }
   };
 
   const handleRetryClick = () => {

--- a/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useGlobalState } from "../../../../core/hooks/useGlobalState";
@@ -10,7 +10,7 @@ import { useExpectationMutation } from "../../../../data/queries/expectation/use
 import useLengthValidation from "../useLengthValidation";
 
 function useExpectationInput() {
-  const { mutate: postExpectation } = useExpectationMutation();
+  const { mutate: postExpectation, isSuccess } = useExpectationMutation();
   const [isFocused, setIsFocused] = useState(false);
   const { content, handleChange } = useLengthValidation({
     initialContent: "",
@@ -21,6 +21,12 @@ function useExpectationInput() {
   const navigate = useNavigate();
 
   const globalDispatch = useGlobalDispatch();
+
+  useEffect(() => {
+    if (isSuccess) {
+      location.reload();
+    }
+  }, [isSuccess]);
 
   const handleSubmit = throttle()(() => {
     if (content.length === 0) {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#154-retry-button-logic

### 💡 작업동기
- 드로잉 결과 페이지 디테일 사항 추가

### 🔑 주요 변경사항
- 기대평 작성 후 toast, button disabled
- 기대평 작성 api 연동

(기대평 기회 부분 추가해야 합니다)

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/8288a4df-41f1-4b11-8c17-fe5dd85b7651">

### 관련 이슈
- closed: #154
