### PR TITLE
퀴즈 이벤트 진입 시 이벤트 기간이 아닐 때의 경우를 처리합니다. 

### DIFF
--- a/strawberry/src/data/queries/quiz/useQuizPlayQuery.tsx
+++ b/strawberry/src/data/queries/quiz/useQuizPlayQuery.tsx
@@ -16,7 +16,11 @@ export function useQuizPlayQuery(subEventId: string | undefined) {
   const query = useQuery<QuizInfo, Error>({
     queryKey: ["quizInfo"],
     queryFn: getQuizInfo,
-    enabled: !!subEventId,
+    retry: 0,
+    onError: () => {
+      alert("잘못된 접근입니다.");
+      location.href = `${window.location.origin}/quiz`;
+    },
   });
 
   return query;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#173-quiz-play-error

### 💡 작업동기
- 퀴즈 이벤트 기간이 아님에도 페이지 진입 시를 처리

### 🔑 주요 변경사항
- query의 onError에 alert후 페이지 이동 코드 추가

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9f1ea874-c5b1-45ca-9558-54d7a4de9016">


### 관련 이슈
- closed: #173 
