### PR TITLE
드로잉 게임의 디테일을 추가합니다.

### DIFF
--- a/strawberry/src/pages/drawingPlay/components/drawingGame/DrawingCanvas.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingGame/DrawingCanvas.tsx
@@ -14,29 +14,22 @@ function DrawingCanvas({ timeLimit }: DrawingCanvasProps) {
     isDrawing,
     imgPath,
     startDrawing,
-    handleMouseUp,
+    handleFinish,
     handleMouseMove,
     pointX,
     pointY,
+    handleArrive,
   } = useDrawingCanvas(timeLimit);
 
   return (
-    <Wrapper
-      $position="relative"
-      width="940px"
-      height="500px"
-      display="flex"
-      $flexdirection="column"
-      $justifycontent="center"
-      $alignitems="center"
-    >
+    <CanvasWrapper onMouseMove={handleMouseMove}>
       <StyledImage src={imgPath} alt="Car" />
       <StyledCanvas
         ref={canvasRef}
         width={940}
         height={500}
-        onMouseUp={(e) => handleMouseUp(e as unknown as MouseEvent)}
-        onMouseMove={handleMouseMove}
+        onMouseUp={handleFinish}
+        onMouseOut={handleFinish}
       />
       <Wrapper
         display="flex"
@@ -49,7 +42,8 @@ function DrawingCanvas({ timeLimit }: DrawingCanvasProps) {
       >
         <StartButton
           onMouseDown={startDrawing}
-          onMouseUp={(e) => handleMouseUp(e as unknown as MouseEvent)}
+          onMouseEnter={handleArrive}
+          onMouseUp={handleFinish}
           $disabled={isDrawing}
         />
         <Label
@@ -57,14 +51,25 @@ function DrawingCanvas({ timeLimit }: DrawingCanvasProps) {
           color={theme.Color.TextIcon.info}
           $margin="0 0 0 5px"
         >
-          start
+          {isDrawing ? "end" : "start"}
         </Label>
       </Wrapper>
-    </Wrapper>
+    </CanvasWrapper>
   );
 }
 
 export default DrawingCanvas;
+
+const CanvasWrapper = styled.div`
+  position: relative;
+  width: 940px;
+  height: 500px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+`;
 
 const StartButton = styled.div<{ $disabled: boolean }>`
   width: 12px;
@@ -72,7 +77,7 @@ const StartButton = styled.div<{ $disabled: boolean }>`
   border-radius: 12px;
   background-color: ${({ theme }) => theme.Color.TextIcon.info};
   border: none;
-  cursor: ${({ $disabled }) => ($disabled ? "none" : "pointer")};
+  cursor: ${({ $disabled }) => ($disabled ? "default" : "pointer")};
   z-index: 10;
 `;
 
@@ -81,6 +86,8 @@ const StyledCanvas = styled.canvas`
   top: 0;
   left: 0;
   z-index: 10;
+  border: 5px dashed #c3c3c3;
+  border-radius: 15px;
 `;
 
 const StyledImage = styled.img`


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#180-add-drawing-play-detail

### 💡 작업동기
- 드로잉 게임에 디테일한 사항을 추가합니다.

### 🔑 주요 변경사항
- 드로잉 캔버스를 벗어났을 때 게임 종료 (상의 후 수정 예정)
- 캔버스 바운더리 표시 (상의 후 수정 예정)
- 게임 플레이 도중 element가 drag 되는 현상 방지
- 시작 후 start버튼 end 버튼으로 변경
- end 버튼에 도착하면 게임 종료
- end 버튼에 도착하면 시작점과 끝점 이어 그림 완성(end버튼에 도착하지 않으면 그림 이어지지 않음)
- 보간법을 사용하여 점 보정 후 서버로 요청
- 리팩토링, 주석 추가

(일단 임의로 바운더리 설정하였고 이에 대해 논의해봐야 합니다!)

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/662ac5ed-e6bd-4148-ad0f-94a67ff684ea">

### 관련 이슈
- closed: #180 
