### PR TITLE
공유하기로 생성되는 url의 리다이렉트 페이지를 만듭니다. 

### DIFF
--- a/strawberry/src/data/entities/Shared.tsx
+++ b/strawberry/src/data/entities/Shared.tsx
@@ -1,0 +1,3 @@
+export interface Shared {
+  redirectUrl: string;
+}

--- a/strawberry/src/data/queries/shared/useSharedRedirectQuery.tsx
+++ b/strawberry/src/data/queries/shared/useSharedRedirectQuery.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from "react-query";
+
+import network from "../../config/network";
+import { Shared } from "../../entities/Shared";
+
+interface UseSharedRedirectQueryProps {
+  sharedCode: string;
+}
+
+export function useSharedRedirectQuery({
+  sharedCode,
+}: UseSharedRedirectQueryProps) {
+  const getSharedRedirect = async () => {
+    {
+      return network.get<Shared>(`url/:sharedCode`, {
+        params: { sharedCode: sharedCode },
+      });
+    }
+  };
+
+  const query = useQuery<Shared, Error>({
+    queryKey: ["shared"],
+    queryFn: getSharedRedirect,
+    enabled: !!sharedCode,
+  });
+
+  return query;
+}

--- a/strawberry/src/router/router.tsx
+++ b/strawberry/src/router/router.tsx
@@ -12,6 +12,7 @@ import LoginRedirectedPage from "../pages/login/LoginRedirectPage";
 import QuizLandingWrapper from "../pages/quizLanding/QuizLandingWrapper";
 import DrawingLandingWrapper from "../pages/drawingLanding/DrawingLandingWrapper";
 import DrawingPlayWrapper from "../pages/drawingPlay/DrawingPlayWrapper";
+import SharedRedirectedPage from "../pages/shared/SharedRedirectedPage";
 
 import LandingPage from "../pages/landing/LandingPage";
 import NewCarPage from "../pages/newCar/components/NewCarPage";
@@ -102,6 +103,10 @@ const router = createBrowserRouter([
         <LoginRedirectedPage /> {/* 리다이렉트 페이지 렌더링 */}
       </PublicRoute>
     ),
+  },
+  {
+    path: "shared/:sharedCode",
+    element: <SharedRedirectedPage />,
   },
 ]);
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#133-add-shared-page

### 💡 작업동기
- 공유하기로 생성되는 url에 따른 페이지를 추가

### 🔑 주요 변경사항
- entity, query 추가
- page 추가
- 라우터에 페이지 추가

(해당 페이지에서 get요청을 보내어 리다이렉트 응답을 받습니다.)

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4197efda-c5f5-4685-9295-0f03ce802a1b">

### 관련 이슈
- closed: #133 
