### PR TITLE
퀴즈 플레이 시 card를 클릭하면 hightlight 해제되는 현상을 해결합니다.

### DIFF
--- a/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
+++ b/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
@@ -68,7 +68,7 @@ const CardInput = (props: CardInputProps) => {
     if (inputRef.current) {
       inputRef.current.focus();
       inputRef.current.setSelectionRange(content.length, content.length);
-      setHighlightedIndex(content.length - 1);
+      setHighlightedIndex(Math.max(0, content.length - 1));
     }
   };
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#192-card-highlight

### 💡 작업동기
- content.length === 0일 때 card를 클릭하면 hightlight가 풀리는 현상을 해결

### 🔑 주요 변경사항
- Math.max를 통해 length가 0일 때 0번째 card가 highlight 되도록 변경

### 관련 이슈
- closed: #192 
