### PR TITLE
드로잉 결과 페이지의 gif를 추가합니다.

### DIFF
--- a/strawberry/generateImageEnum.cjs
+++ b/strawberry/generateImageEnum.cjs
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 // 이미지 파일이 있는 기본 디렉토리
-const baseDir = path.join(__dirname, 'public/assets/');
+const baseDir = path.join(__dirname, "public/assets/");
 
 // 디렉토리를 재귀적으로 탐색하여 이미지 파일 경로를 수집
 const getImageFiles = (dir) => {
@@ -18,7 +18,7 @@ const getImageFiles = (dir) => {
         name: file,
         files: getImageFiles(filePath),
       });
-    } else if (/\.(jpg|jpeg|png|webp|svg)$/i.test(file)) {
+    } else if (/\.(jpg|jpeg|png|webp|svg|gif)$/i.test(file)) {
       results.push(filePath);
     }
   });
@@ -27,20 +27,23 @@ const getImageFiles = (dir) => {
 };
 
 // 이미지를 enum으로 변환
-const generateEnum = (files, parentKey = '') => {
-  let enumString = '';
+const generateEnum = (files, parentKey = "") => {
+  let enumString = "";
 
   files.forEach((file) => {
-    if (typeof file === 'object') {
+    if (typeof file === "object") {
       // 하위 디렉토리의 enum을 생성
-      const key = file.name.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+      const key = file.name.toUpperCase().replace(/[^A-Z0-9]/g, "_");
       enumString += `  ${key}: {\n`;
       enumString += generateEnum(file.files, key);
       enumString += `  },\n`;
     } else {
       // 이미지 파일의 enum을 생성
-      const relativePath = path.relative(baseDir, file).replace(/\\/g, '/');
-      const fileName = path.basename(file, path.extname(file)).toUpperCase().replace(/[^A-Z0-9]/g, '_');
+      const relativePath = path.relative(baseDir, file).replace(/\\/g, "/");
+      const fileName = path
+        .basename(file, path.extname(file))
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, "_");
       enumString += `    ${fileName}: "/assets/${relativePath}",\n`;
     }
   });
@@ -51,11 +54,14 @@ const generateEnum = (files, parentKey = '') => {
 // 메인 함수
 const main = () => {
   const imageFiles = getImageFiles(baseDir);
-  let enumString = 'export const ImageEnum = {\n';
+  let enumString = "export const ImageEnum = {\n";
   enumString += generateEnum(imageFiles);
-  enumString += '}\n';
-  fs.writeFileSync(path.join(__dirname, 'src/core/design_system/ImageEnum.ts'), enumString);
-  console.log('Enum file generated!');
+  enumString += "}\n";
+  fs.writeFileSync(
+    path.join(__dirname, "src/core/design_system/ImageEnum.ts"),
+    enumString,
+  );
+  console.log("Enum file generated!");
 };
 
 main();

--- a/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
@@ -16,9 +16,6 @@ import drawingFinishBG from "/src/assets/images/background/drawingFinishBG.svg";
 import useDrawingFinish from "../../hooks/useDrawingFinish.tsx";
 
 function DrawingFinish() {
-  const gifUrl =
-    "https://s3-alpha-sig.figma.com/img/de82/685d/2752e884c15d3abd92a2193c6288551d?Expires=1724025600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=cZtbhRnyUIPmAzDki-K2F3BZTG1g2UjFubm237vFA8opEAr1ZobTFuXY14OGWp53ox3h7h1Y8HZm1qWxOeDfwvPKKFpfihaYGqUxHCB7FWvPbzyQM5SFNBJ6R3OvVkbLAKQOgiE~BcrT8yMLzGGrRiIccvJjTzuAoZWSLvMPmGKLAPptzJYypk5S2C8mDFxv04yWgjNScTR-A6CooH8-rg0MLhi6sdIpMatk-CFjzK38o3LVqxez63MBOOiK6v8r-O3XTYMsuOLs76Vzk4tLpOfmV9mWZ6jTGQZkfE43v5BqcCRo9DxsK-DdqXo7ItjQnd5Hej7622M1w0CExawoeQ__";
-
   const {
     finalScore,
     highestScore,
@@ -49,7 +46,7 @@ function DrawingFinish() {
           최종 점수
         </Label>
         <Wrapper width="fit-content" height="fit-content" $position="relative">
-          <img src={gifUrl} />
+          <img src={ImageEnum.IMAGES.DRAWING.CELEBRATION} width="500px" />
           <ScoreWrapper>
             <DrawingScore score={Number(finalScore.toFixed(1))} />
           </ScoreWrapper>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#202-add-celebration-gif

### 💡 작업동기
- url로 사용하던 gif를 로컬에 저장하여 대체합니다.

### 🔑 주요 변경사항
- gif 추가
- generateImageEnum에 gif 확장자 추가
- url을 gif path로 변경

### 관련 이슈
- closed: #202 
