### PR TITLE
라디오버튼을 만듭니다.

### DIFF
--- a/strawberry/src/pages/newCar/components/FoundationButton.tsx
+++ b/strawberry/src/pages/newCar/components/FoundationButton.tsx
@@ -1,18 +1,22 @@
 import styled from "styled-components";
 
 type Variant = "SOLID" | "OUTLINE";
-
 interface FoundationButtonStyle {
   variant: Variant;
 }
 
 interface FoundationButtonProps extends FoundationButtonStyle {
   title: string;
+  onClick: () => void;
 }
 
 function FoundationButton(props: FoundationButtonProps) {
-  const { variant, title } = props;
-  return <Button variant={variant}>{title}</Button>;
+  const { variant, title, onClick } = props;
+  return (
+    <Button variant={variant} onClick={onClick}>
+      {title}
+    </Button>
+  );
 }
 
 export default FoundationButton;

--- a/strawberry/src/pages/newCar/components/FoundationRadioButton.tsx
+++ b/strawberry/src/pages/newCar/components/FoundationRadioButton.tsx
@@ -1,25 +1,21 @@
 import styled from "styled-components";
-
 import FoundationButton from "./FoundationButton";
 
 interface FoundationRadioButtonsProps<T, S, A> {
   buttons: { title: string; value: T }[];
-  dispatch: (action: A) => void;
-  actionCreator: (value: T) => A;
+  actionCreator: (value: T) => void;
   selector: string;
 }
 
 function FoundationRadioButtons<T, S, A>({
   buttons,
-  dispatch,
   actionCreator,
   selector,
 }: FoundationRadioButtonsProps<T, S, A>) {
   const selectedValue = selector;
 
   const handleButtonClick = (buttonValue: T) => {
-    const action = actionCreator(buttonValue);
-    dispatch(action);
+    actionCreator(buttonValue);
   };
 
   return (

--- a/strawberry/src/pages/newCar/components/FoundationRadioButton.tsx
+++ b/strawberry/src/pages/newCar/components/FoundationRadioButton.tsx
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+
+import FoundationButton from "./FoundationButton";
+
+interface FoundationRadioButtonsProps<T, S, A> {
+  buttons: { title: string; value: T }[];
+  dispatch: (action: A) => void;
+  actionCreator: (value: T) => A;
+  selector: string;
+}
+
+function FoundationRadioButtons<T, S, A>({
+  buttons,
+  dispatch,
+  actionCreator,
+  selector,
+}: FoundationRadioButtonsProps<T, S, A>) {
+  const selectedValue = selector;
+
+  const handleButtonClick = (buttonValue: T) => {
+    const action = actionCreator(buttonValue);
+    dispatch(action);
+  };
+
+  return (
+    <ButtonGroup>
+      {buttons.map(({ title, value }) => (
+        <FoundationButton
+          key={title}
+          title={title}
+          variant={selectedValue === value ? "SOLID" : "OUTLINE"}
+          onClick={() => handleButtonClick(value)}
+        />
+      ))}
+    </ButtonGroup>
+  );
+}
+
+export default FoundationRadioButtons;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 10px;
+`;

--- a/strawberry/src/pages/newCar/components/FoundationRadioButton.tsx
+++ b/strawberry/src/pages/newCar/components/FoundationRadioButton.tsx
@@ -1,17 +1,17 @@
 import styled from "styled-components";
 import FoundationButton from "./FoundationButton";
 
-interface FoundationRadioButtonsProps<T, S, A> {
+interface FoundationRadioButtonsProps<T> {
   buttons: { title: string; value: T }[];
   actionCreator: (value: T) => void;
   selector: string;
 }
 
-function FoundationRadioButtons<T, S, A>({
+function FoundationRadioButtons<T>({
   buttons,
   actionCreator,
   selector,
-}: FoundationRadioButtonsProps<T, S, A>) {
+}: FoundationRadioButtonsProps<T>) {
   const selectedValue = selector;
 
   const handleButtonClick = (buttonValue: T) => {

--- a/strawberry/src/pages/newCar/components/design/ExteriorCalligraphy.tsx
+++ b/strawberry/src/pages/newCar/components/design/ExteriorCalligraphy.tsx
@@ -1,6 +1,6 @@
 import { Wrapper, Label } from "../../../../core/design_system";
-
 import { useNewCarDispatch } from "../../hooks/useNewCarDispatch";
+
 import { useNewCarState } from "../../hooks/useNewCarState";
 import {
   ExteriorCalligraphyType,
@@ -21,10 +21,12 @@ function ExteriorCalligraphy() {
   const state = useNewCarState();
   const dispatch = useNewCarDispatch();
 
-  const actionCreator = (value: ExteriorCalligraphyType): NewCarAction => ({
-    type: "SET_EXTERIOR_CALLIGRAPHY_TYPE",
-    newType: value,
-  });
+  const actionCreator = (value: ExteriorCalligraphyType) => {
+    dispatch({
+      type: "SET_EXTERIOR_CALLIGRAPHY_TYPE",
+      newType: value,
+    });
+  };
 
   const selector = state.exteriorCalligraphyType;
 
@@ -37,7 +39,6 @@ function ExteriorCalligraphy() {
           NewCarAction
         >
           buttons={buttons}
-          dispatch={dispatch}
           actionCreator={actionCreator}
           selector={selector}
         />

--- a/strawberry/src/pages/newCar/components/design/ExteriorCalligraphy.tsx
+++ b/strawberry/src/pages/newCar/components/design/ExteriorCalligraphy.tsx
@@ -1,82 +1,49 @@
 import { Wrapper, Label } from "../../../../core/design_system";
-import FoundationButton from "../FoundationButton";
 
-type CalligraphyType = "NORMAL" | "BLACKINK";
-
-interface Calligraphy {
-  type: CalligraphyType;
-  name: string;
-  color: string;
-}
-
-const calligraphyDatas: Calligraphy[] = [
-  {
-    type: "NORMAL",
-    name: "얼씨 브래스 메탈릭 매트",
-    color: "brown",
-  },
-  {
-    type: "NORMAL",
-    name: "크리미 화이트 펄",
-    color: "whitePearl",
-  },
-  {
-    type: "NORMAL",
-    name: "사이버 세이지 펄",
-    color: "cyber",
-  },
-  {
-    type: "NORMAL",
-    name: "페블 블루 펄",
-    color: "blue",
-  },
-  {
-    type: "NORMAL",
-    name: "오카도 그린 펄",
-    color: "green",
-  },
-  {
-    type: "NORMAL",
-    name: "테라코타 오렌지",
-    color: "orange",
-  },
-  {
-    type: "NORMAL",
-    name: "마그네틱 그레이 메탈릭",
-    color: "gray",
-  },
-  {
-    type: "NORMAL",
-    name: "어비스 블랙 펄",
-    color: "black",
-  },
-  {
-    type: "BLACKINK",
-    name: "크리미 화이트 펄",
-    color: "whitePearl",
-  },
-  {
-    type: "BLACKINK",
-    name: "크리미 화이트 매트",
-    color: "whiteMatte",
-  },
-  {
-    type: "BLACKINK",
-    name: "어비스 블랙 펄",
-    color: "black",
-  },
-];
+import { useNewCarDispatch } from "../../hooks/useNewCarDispatch";
+import { useNewCarState } from "../../hooks/useNewCarState";
+import {
+  ExteriorCalligraphyType,
+  NewCarState,
+  NewCarAction,
+} from "../../models";
+import FoundationRadioButtons from "../FoundationRadioButton";
 
 function ExteriorCalligraphy() {
+  const buttons = [
+    { title: "캘리그래피", value: "NORMAL" as ExteriorCalligraphyType },
+    {
+      title: "캘리그래피(블랙잉크)",
+      value: "BLACKINK" as ExteriorCalligraphyType,
+    },
+  ];
+
+  const state = useNewCarState();
+  const dispatch = useNewCarDispatch();
+
+  const actionCreator = (value: ExteriorCalligraphyType): NewCarAction => ({
+    type: "SET_EXTERIOR_CALLIGRAPHY_TYPE",
+    newType: value,
+  });
+
+  const selector = state.exteriorCalligraphyType;
+
   return (
     <Wrapper>
       <Wrapper>
-        <FoundationButton variant="SOLID" title="캘리그래피" />
-        <FoundationButton variant="OUTLINE" title="캘리그래피(블랙잉크)" />
+        <FoundationRadioButtons<
+          ExteriorCalligraphyType,
+          NewCarState,
+          NewCarAction
+        >
+          buttons={buttons}
+          dispatch={dispatch}
+          actionCreator={actionCreator}
+          selector={selector}
+        />
       </Wrapper>
       <img />
-      <Label $token="Title2Medium"></Label>
-      {}
+      <Label $token="Title2Medium">{state.exteriorCalligraphyType}</Label>
     </Wrapper>
   );
 }

--- a/strawberry/src/pages/newCar/components/design/ExteriorCalligraphy.tsx
+++ b/strawberry/src/pages/newCar/components/design/ExteriorCalligraphy.tsx
@@ -2,11 +2,7 @@ import { Wrapper, Label } from "../../../../core/design_system";
 import { useNewCarDispatch } from "../../hooks/useNewCarDispatch";
 
 import { useNewCarState } from "../../hooks/useNewCarState";
-import {
-  ExteriorCalligraphyType,
-  NewCarState,
-  NewCarAction,
-} from "../../models";
+import { ExteriorCalligraphyType } from "../../models";
 import FoundationRadioButtons from "../FoundationRadioButton";
 
 function ExteriorCalligraphy() {
@@ -33,11 +29,7 @@ function ExteriorCalligraphy() {
   return (
     <Wrapper>
       <Wrapper>
-        <FoundationRadioButtons<
-          ExteriorCalligraphyType,
-          NewCarState,
-          NewCarAction
-        >
+        <FoundationRadioButtons<ExteriorCalligraphyType>
           buttons={buttons}
           actionCreator={actionCreator}
           selector={selector}

--- a/strawberry/src/pages/newCar/components/design/NewCarDesignDetail.tsx
+++ b/strawberry/src/pages/newCar/components/design/NewCarDesignDetail.tsx
@@ -43,10 +43,12 @@ const NewCarDesignDetail: React.FC = () => {
     { title: "Rear", value: "REAR" as ExteriorType },
   ];
 
-  const actionCreator = (value: ExteriorType): NewCarAction => ({
-    type: "SET_EXTERIOR_TYPE",
-    newType: value,
-  });
+  const actionCreator = (value: ExteriorType) => {
+    dispatch({
+      type: "SET_EXTERIOR_TYPE",
+      newType: value,
+    });
+  };
 
   const selector = state.exteriorType;
 
@@ -89,7 +91,6 @@ const NewCarDesignDetail: React.FC = () => {
     <Wrapper $position="relative" height="fit-content">
       <FoundationRadioButtons<ExteriorType, NewCarState, NewCarAction>
         buttons={buttons}
-        dispatch={dispatch}
         actionCreator={actionCreator}
         selector={selector}
       />

--- a/strawberry/src/pages/newCar/components/design/NewCarDesignDetail.tsx
+++ b/strawberry/src/pages/newCar/components/design/NewCarDesignDetail.tsx
@@ -5,6 +5,10 @@ import { Wrapper } from "../../../../core/design_system";
 import { Point } from "../../../drawingPlay/models";
 
 import DetailCarousel from "./DetailCarousel";
+import FoundationRadioButtons from "../FoundationRadioButton";
+import { useNewCarState } from "../../hooks/useNewCarState";
+import { useNewCarDispatch } from "../../hooks/useNewCarDispatch";
+import { ExteriorType, NewCarAction, NewCarState } from "../../models";
 
 export interface DesignDetail {
   title: string;
@@ -31,6 +35,21 @@ const coordinatesData: Point[] = [
 ];
 
 const NewCarDesignDetail: React.FC = () => {
+  const state = useNewCarState();
+  const dispatch = useNewCarDispatch();
+
+  const buttons = [
+    { title: "Front", value: "FRONT" as ExteriorType },
+    { title: "Rear", value: "REAR" as ExteriorType },
+  ];
+
+  const actionCreator = (value: ExteriorType): NewCarAction => ({
+    type: "SET_EXTERIOR_TYPE",
+    newType: value,
+  });
+
+  const selector = state.exteriorType;
+
   const imageContainerRef = useRef<HTMLImageElement | null>(null);
   const [imageSize, setImageSize] = useState<{ width: number; height: number }>(
     { width: 0, height: 0 },
@@ -68,6 +87,12 @@ const NewCarDesignDetail: React.FC = () => {
 
   return (
     <Wrapper $position="relative" height="fit-content">
+      <FoundationRadioButtons<ExteriorType, NewCarState, NewCarAction>
+        buttons={buttons}
+        dispatch={dispatch}
+        actionCreator={actionCreator}
+        selector={selector}
+      />
       <img
         ref={imageContainerRef}
         width="100%"

--- a/strawberry/src/pages/newCar/components/design/NewCarDesignDetail.tsx
+++ b/strawberry/src/pages/newCar/components/design/NewCarDesignDetail.tsx
@@ -8,7 +8,7 @@ import DetailCarousel from "./DetailCarousel";
 import FoundationRadioButtons from "../FoundationRadioButton";
 import { useNewCarState } from "../../hooks/useNewCarState";
 import { useNewCarDispatch } from "../../hooks/useNewCarDispatch";
-import { ExteriorType, NewCarAction, NewCarState } from "../../models";
+import { ExteriorType } from "../../models";
 
 export interface DesignDetail {
   title: string;
@@ -89,7 +89,7 @@ const NewCarDesignDetail: React.FC = () => {
 
   return (
     <Wrapper $position="relative" height="fit-content">
-      <FoundationRadioButtons<ExteriorType, NewCarState, NewCarAction>
+      <FoundationRadioButtons<ExteriorType>
         buttons={buttons}
         actionCreator={actionCreator}
         selector={selector}

--- a/strawberry/src/pages/newCar/models/Calligraphy.tsx
+++ b/strawberry/src/pages/newCar/models/Calligraphy.tsx
@@ -1,0 +1,68 @@
+import {
+  ExteriorCalligraphyType,
+  ExteriorCalligraphyColor,
+} from "./NewCarTypes";
+
+export interface ExteriorCalligraphy {
+  type: ExteriorCalligraphyType;
+  color: ExteriorCalligraphyColor;
+  name: string;
+}
+
+export const calligraphyDatas: ExteriorCalligraphy[] = [
+  {
+    type: "NORMAL",
+    color: "BROWN",
+    name: "얼씨 브래스 메탈릭 매트",
+  },
+  {
+    type: "NORMAL",
+    color: "WHITEPEARL",
+    name: "크리미 화이트 펄",
+  },
+  {
+    type: "NORMAL",
+    color: "CYBER",
+    name: "사이버 세이지 펄",
+  },
+  {
+    type: "NORMAL",
+    color: "BLUE",
+    name: "페블 블루 펄",
+  },
+  {
+    type: "NORMAL",
+    color: "GREEN",
+    name: "오카도 그린 펄",
+  },
+  {
+    type: "NORMAL",
+    color: "ORANGE",
+    name: "테라코타 오렌지",
+  },
+  {
+    type: "NORMAL",
+    color: "GRAY",
+    name: "마그네틱 그레이 메탈릭",
+  },
+  {
+    type: "NORMAL",
+    color: "BLACK",
+    name: "어비스 블랙 펄",
+  },
+  {
+    type: "BLACKINK",
+    color: "WHITEPEARL",
+    name: "크리미 화이트 펄",
+  },
+  {
+    type: "BLACKINK",
+    color: "WHITEMATTE",
+    name: "크리미 화이트 매트",
+  },
+  {
+    type: "BLACKINK",
+    color: "BLACK",
+    name: "어비스 블랙 펄",
+  },
+];


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
feat/#197-radio-button

### 💡 작업동기
신차 소개에 사용되는 라디오 버튼을 만들었습니당 :)

### 🔑 주요 변경사항
- context api를 사용하여 상태 관리를 하기 때문에, useState 대신 context를 넘길 수 있는 방안을 모색해보았습니당.
- 넘기는 프롭스들이 많네요 ㅜㅜ 더 쉽게 관리할 수 있는 방법이 생각나시면 말씀해주세용 :) => pr 작성하면서 생각해버렸습니당....

원래는 제네릭 타입 3개를 써서, state와 dispatch를 모두 받게 코딩했는데 생각해보니 그럴 필요가 전혀 없었네요...
미리 정의 된 state와 함수를 넘기면 되는거였네용 ... ㅜㅜ
=> props도 2개 줄이고, 제네릭도 2개 줄일 수 있었어요... 행복합니다...:)


1. 라디오 버튼 안에 들어갈 버튼들을 객체 배열로 만든다 => buttons
2. 버튼이 눌렀을 때 실행되어야 할 action을 미리 정의한다 => actionCreator
3. 변경되어야 하는 context state를 미리 정의한다. => selector
4. 제네릭 타입에 radio button value type을 넘겨줍니당 :)

**사용법**
```typescript
 const buttons = [
    { title: "캘리그래피", value: "NORMAL" as ExteriorCalligraphyType },
    {
      title: "캘리그래피(블랙잉크)",
      value: "BLACKINK" as ExteriorCalligraphyType,
    },
  ];

  const state = useNewCarState();
  const dispatch = useNewCarDispatch();

 const actionCreator = (value: ExteriorCalligraphyType) => {
    dispatch({
      type: "SET_EXTERIOR_CALLIGRAPHY_TYPE",
      newType: value,
    });
  };

  const selector = state.exteriorCalligraphyType;


 <FoundationRadioButtons<ExteriorCalligraphyType>
          buttons={buttons}
          actionCreator={actionCreator}
          selector={selector}
        />
```


### 관련 이슈
closed: #197 
