### PR TITLE
subEventId에 대한 처리를 추가합니다. 

### DIFF
--- a/strawberry/src/data/entities/DrawingLanding.tsx
+++ b/strawberry/src/data/entities/DrawingLanding.tsx
@@ -8,4 +8,5 @@ export interface DrawingLanding {
   eventImgUrls: EventImageUrl;
   startAt: string;
   endAt: string;
+  subEventId: number;
 }

--- a/strawberry/src/data/queries/drawing/useDrawingFinishQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingFinishQuery.tsx
@@ -5,7 +5,7 @@ import network from "../../config/network";
 import { DrawingFinish } from "../../entities/DrawingFinish";
 
 interface UseDrawingFinishQueryProps {
-  subEventId: number;
+  subEventId: string | undefined;
 }
 
 export function useDrawingFinishQuery({

--- a/strawberry/src/data/queries/drawing/useDrawingPlayMutation.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingPlayMutation.tsx
@@ -6,7 +6,7 @@ import { DrawingResult } from "../../entities/DrawingResult";
 
 interface UseDrawingPlayMutationBody {
   positions: { x: number; y: number }[];
-  subEventId: number;
+  subEventId: string | undefined;
   sequence: number;
 }
 

--- a/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingPlayQuery.tsx
@@ -5,7 +5,7 @@ import network from "../../config/network";
 import { DrawingPlay } from "../../entities/DrawingPlay";
 
 interface UseDrawingPlayQueryProps {
-  subEventId: number | undefined;
+  subEventId: string | undefined;
   eventPlayType: "NORMAL" | "EXPECTATION" | "SHARED" | undefined;
 }
 

--- a/strawberry/src/data/queries/drawing/useDrawingSharedQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingSharedQuery.tsx
@@ -4,7 +4,7 @@ import network from "../../config/network";
 import { DrawingShared } from "../../entities/DrawingShared";
 
 interface UseDrawingRankQueryProps {
-  subEventId: number;
+  subEventId: string | undefined;
 }
 
 export function useDrawingSharedQuery({

--- a/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
@@ -15,7 +15,7 @@ function DrawingBanner() {
 
   const handleEventClick = () => {
     checkLogin(() => {
-      navigate("/drawing/play");
+      navigate(`/drawing/play/${landData?.subEventId}`);
     });
   };
 

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingCanvas.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingCanvas.tsx
@@ -8,6 +8,7 @@ import { useDrawingPlayDispatch } from "./useDrawingPlayDispatch";
 import { useDrawingPlayState } from "./useDrawingPlayState";
 
 import { extractInterpolatedPoints } from "../services/extractInterpolatedPoints";
+import { useParams } from "react-router-dom";
 
 const customLineStyle: LineStyle = {
   stroke: "#46474C",
@@ -19,6 +20,7 @@ const customLineStyle: LineStyle = {
 };
 
 export function useDrawingCanvas(timeLimit = 7) {
+  const { subEventId } = useParams();
   const [userPoints, setUserPoints] = useState<Point[]>([]);
   const [timer, setTimer] = useState<number>(timeLimit);
 
@@ -92,7 +94,7 @@ export function useDrawingCanvas(timeLimit = 7) {
       setUserPoints((prevPoints) => [...prevPoints, ...interpolatedPoints]);
       postPoints({
         positions: userPoints,
-        subEventId: 4,
+        subEventId: subEventId,
         sequence: stage,
       });
 
@@ -106,7 +108,7 @@ export function useDrawingCanvas(timeLimit = 7) {
 
       postPoints({
         positions: [...userPoints, ...interpolatedPoints],
-        subEventId: 4,
+        subEventId: subEventId,
         sequence: stage,
       });
 

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
@@ -4,19 +4,20 @@ import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
 
 import { useDrawingSharedQuery } from "../../../data/queries/drawing/useDrawingSharedQuery";
 import { useDrawingFinishQuery } from "../../../data/queries/drawing/useDrawingFinishQuery";
+import { useParams } from "react-router-dom";
 
 function useDrawingFinish() {
+  const { subEventId } = useParams();
   const globalDispatch = useGlobalDispatch();
   const { data: drawingFinish } = useDrawingFinishQuery({
-    subEventId: 4,
+    subEventId: subEventId,
   });
   const {
     data: sharedData,
     refetch: getSharedData,
     isStale,
   } = useDrawingSharedQuery({
-    // 컨텍스트 값으로 대체
-    subEventId: 4,
+    subEventId: subEventId,
   });
 
   useEffect(() => {

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingPlayPage.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingPlayPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useParams } from "react-router-dom";
 
 import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
 
@@ -11,12 +12,12 @@ import { useDrawingPlayQuery } from "../../../data/queries/drawing/useDrawingPla
 function useDrawingPlayPage() {
   const { status } = useDrawingPlayState();
   const { isBlocked, proceed, reset } = useNavigationBlocker();
-
+  const { subEventId } = useParams();
   const drawingPlayDispatch = useDrawingPlayDispatch();
   const dispatch = useGlobalDispatch();
 
   const { data: drawingInfo } = useDrawingPlayQuery({
-    subEventId: 4,
+    subEventId: subEventId,
     eventPlayType: "NORMAL",
   });
 

--- a/strawberry/src/router/router.tsx
+++ b/strawberry/src/router/router.tsx
@@ -84,7 +84,7 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: "drawing/play",
+        path: "drawing/play/:subEventId",
         element: (
           <>
             <DrawingPlayWrapper />


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#194-add-subEventId

### 💡 작업동기
- 드로잉에서의 subEventId를 처리합니다.

### 🔑 주요 변경사항
- 드로잉 게임 pathparam 추가
- 임의로 설정한 subEventId useParam 처리
- 드로잉 랜딩 이벤트 버튼에 subEventId 처리

### 관련 이슈
- closed: #194 
