### PR TITLE
드로잉, 드로잉 플레이의 기회 부분을 포함한 디테일을 추가합니다.

### DIFF
--- a/strawberry/src/core/design_system/buttons/EventButton.tsx
+++ b/strawberry/src/core/design_system/buttons/EventButton.tsx
@@ -64,8 +64,8 @@ const StyledButton = styled.button<{ type: ButtonType; status: ButtonStatus }>`
   border-radius: 50px;
   ${({ theme }) => theme.Shadow.Strong};
   ${({ theme }) => theme.Typography.Title3Medium};
+  cursor: ${({ status }) => (status === "DEFAULT" ? "pointer" : "default")};
 
-  // status css
   ${({ type, status, theme }) => {
     if (type === "DRAWING" && status === "DEFAULT") {
       return css`
@@ -97,7 +97,7 @@ const StyledButton = styled.button<{ type: ButtonType; status: ButtonStatus }>`
         color: ${theme.Color.TextIcon.info};
       `;
     }
-  }}
+  }};
 `;
 
 const ContentWrapper = styled.div`

--- a/strawberry/src/core/utils/getNowTime.ts
+++ b/strawberry/src/core/utils/getNowTime.ts
@@ -1,0 +1,17 @@
+export function getNowTime() {
+  const now = new Date(Date.now());
+
+  const year = String(now.getFullYear());
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+
+  return {
+    year,
+    month,
+    day,
+    hours,
+    minutes,
+  };
+}

--- a/strawberry/src/data/entities/DrawingFinish.tsx
+++ b/strawberry/src/data/entities/DrawingFinish.tsx
@@ -2,4 +2,6 @@ export interface DrawingFinish {
   totalScore: number;
   maxScore: number;
   chance: number;
+  expectationBonusChance: number;
+  shareBonusChance: number;
 }

--- a/strawberry/src/data/entities/EventUserInfo.tsx
+++ b/strawberry/src/data/entities/EventUserInfo.tsx
@@ -1,13 +1,12 @@
 export interface EventUserInfo {
   lastVisitedAt: string;
-  // sharedUrl: string;
-  // sharedScore: number;
-  // priorityScore: number;
-  // lottoScore: number;
+  lastChargeAt: string;
+  sharedScore: number;
+  priorityScore: number;
+  lottoScore: number;
   gameScore: number;
   chance: number;
   expectationBonusChance: number;
   shareBonusChance: number;
+  winner: string;
 }
-
-// expectationBonusChance: -1 => 기대평 작성 안함 // 0  => 기대평 작성 하고 게임 한거 // 1 => 기대평 작성 하고 게임은 안한거

--- a/strawberry/src/pages/drawingLanding/components/drawingRank/DrawingRank.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingRank/DrawingRank.tsx
@@ -5,8 +5,11 @@ import { useDrawingLandingState } from "../../hooks/useDrawingLandingState";
 import Rank from "./Rank";
 import MyDrawingScore from "./MyDrawingScore";
 
+import { getNowTime } from "../../../../core/utils/getNowTime";
+
 function DrawingRank() {
   const { drawingRankData: rankData } = useDrawingLandingState();
+  const { year, month, day, hours, minutes } = getNowTime();
 
   return (
     <Wrapper
@@ -30,14 +33,14 @@ function DrawingRank() {
           color={theme.Color.TextIcon.info}
           $textalign="right"
         >
-          24.07.19 10:55 업데이트
+          {`${year.slice(2, year.length)}.${month}.${day} ${hours}:${minutes} 업데이트`}
         </Label>
         {rankData?.map((data, index) => (
           <Rank
             key={index}
             rank={index + 1}
             name={data.name}
-            score={data.score ?? 0}
+            score={Number(data.score.toFixed(1)) ?? 0}
           />
         ))}
       </Wrapper>

--- a/strawberry/src/pages/drawingLanding/components/drawingRank/MyDrawingScore.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingRank/MyDrawingScore.tsx
@@ -13,7 +13,7 @@ function MyDrawingScore() {
         내 최고 점수
       </Label>
       <Label $token="Title3Medium" color={theme.Color.TextIcon.strong}>
-        {eventUserData?.gameScore}점
+        {Number(eventUserData?.gameScore.toFixed(1))}점
       </Label>
     </MyScore>
   );

--- a/strawberry/src/pages/drawingLanding/components/drawingRank/Rank.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingRank/Rank.tsx
@@ -59,6 +59,7 @@ const RankLabelWrapper = styled.div`
 
 const RankStyle = styled.div`
   width: auto;
+  margin-top: 16px;
   padding: 16px 43px;
   display: flex;
   justify-content: space-between;

--- a/strawberry/src/pages/drawingLanding/hooks/useDrawingChance.tsx
+++ b/strawberry/src/pages/drawingLanding/hooks/useDrawingChance.tsx
@@ -1,57 +1,35 @@
 import { useMemo } from "react";
-import { EventUserInfo } from "../models";
+import { EventUserInfo } from "../../../data/entities/EventUserInfo";
 
-function formatLastPlayTime(lastPlayTime: string): string {
-  const lastPlayDate = new Date(lastPlayTime);
-
-  const hours = lastPlayDate.getHours().toString().padStart(2, "0");
-  const minutes = lastPlayDate.getMinutes().toString().padStart(2, "0");
-  return `마지막 게임 참여 시간 : ${hours}시 ${minutes}분`;
-}
-
-function formatTimeUntilNextChance(lastPlayTime: string): string {
-  const lastPlayDate = new Date(lastPlayTime);
-  const nextChanceDate = new Date(lastPlayDate.getTime() + 8 * 60 * 60 * 1000);
-
-  const now = new Date();
-  const timeDifference = nextChanceDate.getTime() - now.getTime();
-
-  if (timeDifference <= 0) {
-    return "1회 도전할 수 있어요!";
-  }
-
-  const hoursRemaining = Math.floor(timeDifference / (1000 * 60 * 60));
-  const minutesRemaining = Math.floor(
-    (timeDifference % (1000 * 60 * 60)) / (1000 * 60),
-  );
-
-  return `${hoursRemaining}시간 ${minutesRemaining}분 후에 도전할 수 있어요!`;
-}
+import { getChanceFromLastTime } from "../services/getChanceFromLastTime";
+import { formatTimeUntilNextChance } from "../services/formatTimeUntilNextChance";
 
 export function useDrawingChance(eventUserData: EventUserInfo | undefined) {
   return useMemo(() => {
     if (!eventUserData) {
-      return;
+      return "";
     }
 
-    const chance: number = eventUserData?.chance ?? 0;
+    let chance: number = eventUserData.chance ?? 0;
     const bonusChance: number =
-      (eventUserData?.expectationBonusChance ?? 0) +
-      (eventUserData?.shareBonusChance ?? 0);
+      (eventUserData.expectationBonusChance ?? 0) +
+      (eventUserData.shareBonusChance ?? 0);
 
-    const lastPlayTime: string = eventUserData?.lastVisitedAt ?? "";
-    const formattedLastPlayTime = formatLastPlayTime(lastPlayTime);
+    const lastPlayTime: string = eventUserData.lastChargeAt ?? "";
+
+    const chanceFromLastTime = getChanceFromLastTime(lastPlayTime);
+    chance = Math.min(2, chance + chanceFromLastTime);
 
     let text = "";
 
     if (chance > 0) {
       if (bonusChance > 0) {
-        text = `${formattedLastPlayTime}\n${chance}회 + 보너스 ${bonusChance}회, 총 ${chance + bonusChance}회 도전할 수 있어요!`;
+        text = `${chance}회 + 보너스 ${bonusChance}회, 총 ${chance + bonusChance}회 도전할 수 있어요!`;
       } else {
-        text = `${formattedLastPlayTime}\n${chance}회 도전할 수 있어요!`;
+        text = `${chance}회 도전할 수 있어요!`;
       }
     } else {
-      text = `${formattedLastPlayTime}\n${formatTimeUntilNextChance(lastPlayTime)}`;
+      text = `${formatTimeUntilNextChance(lastPlayTime)}`;
     }
 
     return text;

--- a/strawberry/src/pages/drawingLanding/services/formatLastPlayTime.ts
+++ b/strawberry/src/pages/drawingLanding/services/formatLastPlayTime.ts
@@ -1,0 +1,8 @@
+export function formatLastPlayTime(lastPlayTime: string): string {
+  const lastPlayDate = new Date(lastPlayTime);
+  lastPlayDate.setHours(lastPlayDate.getHours());
+
+  const hours = lastPlayDate.getHours().toString().padStart(2, "0");
+  const minutes = lastPlayDate.getMinutes().toString().padStart(2, "0");
+  return `마지막 게임 참여 시간 : ${hours}시 ${minutes}분`;
+}

--- a/strawberry/src/pages/drawingLanding/services/formatTimeUntilNextChance.ts
+++ b/strawberry/src/pages/drawingLanding/services/formatTimeUntilNextChance.ts
@@ -1,0 +1,15 @@
+export function formatTimeUntilNextChance(lastPlayTime: string): string {
+  const lastPlayDate = new Date(lastPlayTime);
+  lastPlayDate.setHours(lastPlayDate.getHours());
+  const nextChanceDate = new Date(lastPlayDate.getTime() + 4 * 60 * 60 * 1000);
+
+  const now = new Date();
+  const timeDifference = nextChanceDate.getTime() - now.getTime();
+
+  const hoursRemaining = Math.floor(timeDifference / (1000 * 60 * 60));
+  const minutesRemaining = Math.floor(
+    (timeDifference % (1000 * 60 * 60)) / (1000 * 60),
+  );
+
+  return `${hoursRemaining}시간 ${minutesRemaining}분 후에 도전할 수 있어요!`;
+}

--- a/strawberry/src/pages/drawingLanding/services/getChanceFromLastTime.ts
+++ b/strawberry/src/pages/drawingLanding/services/getChanceFromLastTime.ts
@@ -1,0 +1,18 @@
+export function getChanceFromLastTime(lastPlayTime: string): number {
+  const lastPlayDate = new Date(lastPlayTime);
+  lastPlayDate.setHours(lastPlayDate.getHours());
+  const nextChanceDate = new Date(lastPlayDate.getTime() + 4 * 60 * 60 * 1000);
+
+  const now = new Date();
+  const timeDifference = now.getTime() - nextChanceDate.getTime();
+
+  if (timeDifference >= 4 * 60 * 60 * 1000) {
+    return 2;
+  }
+
+  if (timeDifference >= 0) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/components/drawingFinish/DrawingFinish.tsx
@@ -15,6 +15,8 @@ import HighestScore from "./HighestScore";
 import drawingFinishBG from "/src/assets/images/background/drawingFinishBG.svg";
 import useDrawingFinish from "../../hooks/useDrawingFinish.tsx";
 
+import { makeChanceMsg } from "../../services/makeChanceMsg.ts";
+
 function DrawingFinish() {
   const gifUrl =
     "https://s3-alpha-sig.figma.com/img/de82/685d/2752e884c15d3abd92a2193c6288551d?Expires=1724025600&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=cZtbhRnyUIPmAzDki-K2F3BZTG1g2UjFubm237vFA8opEAr1ZobTFuXY14OGWp53ox3h7h1Y8HZm1qWxOeDfwvPKKFpfihaYGqUxHCB7FWvPbzyQM5SFNBJ6R3OvVkbLAKQOgiE~BcrT8yMLzGGrRiIccvJjTzuAoZWSLvMPmGKLAPptzJYypk5S2C8mDFxv04yWgjNScTR-A6CooH8-rg0MLhi6sdIpMatk-CFjzK38o3LVqxez63MBOOiK6v8r-O3XTYMsuOLs76Vzk4tLpOfmV9mWZ6jTGQZkfE43v5BqcCRo9DxsK-DdqXo7ItjQnd5Hej7622M1w0CExawoeQ__";
@@ -24,8 +26,15 @@ function DrawingFinish() {
     highestScore,
     handleSharedClick,
     chance,
+    expectationChance,
+    shareChance,
     handleRetryClick,
   } = useDrawingFinish();
+
+  const realShareChance = shareChance === -1 ? 0 : shareChance;
+  const realExpectationChance =
+    expectationChance === -1 ? 0 : expectationChance;
+  const totalChance = chance + realShareChance + realExpectationChance;
 
   return (
     <>
@@ -67,8 +76,9 @@ function DrawingFinish() {
             $token="Heading1Regular"
             color={theme.Color.TextIcon.info}
             $textalign="center"
+            width="100%"
           >
-            {`기회가 ${chance}번 남았어요!\n링크 공유 / 기대평 작성으로 추가 재도전 기회를 얻으세요!`}
+            {makeChanceMsg({ totalChance, expectationChance, shareChance })}
           </Label>
         </Wrapper>
         <Wrapper $margin="16px 0 0 0">
@@ -87,7 +97,7 @@ function DrawingFinish() {
             </Label>
           </StyledButton>
 
-          {chance > 0 ? (
+          {totalChance > 0 ? (
             <RetryDefaultButton onClick={handleRetryClick}>
               <img src={ImageEnum.ICONS.RETRYBUTTON} alt="url" width="100px" />
               <Label

--- a/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
+++ b/strawberry/src/pages/drawingPlay/hooks/useDrawingFinish.tsx
@@ -48,6 +48,8 @@ function useDrawingFinish() {
     finalScore: drawingFinish?.totalScore ?? 0,
     highestScore: drawingFinish?.maxScore ?? 0,
     chance: drawingFinish?.chance ?? 0,
+    expectationChance: drawingFinish?.expectationBonusChance ?? 0,
+    shareChance: drawingFinish?.shareBonusChance ?? 0,
     handleSharedClick,
     handleRetryClick,
   };

--- a/strawberry/src/pages/drawingPlay/services/makeChanceMsg.ts
+++ b/strawberry/src/pages/drawingPlay/services/makeChanceMsg.ts
@@ -33,8 +33,8 @@ export function makeChanceMsg({
 
   const key = [
     totalChance > 0 ? "POSSIBLE" : "IMPOSSIBLE",
-    expectationChance === -1 ? "EXPECTATION" : "",
     shareChance === -1 ? "SHARE" : "",
+    expectationChance === -1 ? "EXPECTATION" : "",
   ]
     .filter(Boolean)
     .join("_") as keyof messageType;

--- a/strawberry/src/pages/drawingPlay/services/makeChanceMsg.ts
+++ b/strawberry/src/pages/drawingPlay/services/makeChanceMsg.ts
@@ -1,0 +1,43 @@
+interface makeInfoMsgProps {
+  totalChance: number;
+  expectationChance: number;
+  shareChance: number;
+}
+
+interface messageType {
+  POSSIBLE_SHARE_EXPECTATION: string;
+  POSSIBLE_EXPECTATION: string;
+  POSSIBLE_SHARE: string;
+  POSSIBLE: string;
+  IMPOSSIBLE_SHARE_EXPECTATION: string;
+  IMPOSSIBLE_EXPECTATION: string;
+  IMPOSSIBLE_SHARE: string;
+  IMPOSSIBLE: string;
+}
+
+export function makeChanceMsg({
+  totalChance,
+  expectationChance,
+  shareChance,
+}: makeInfoMsgProps): string {
+  const messages: messageType = {
+    POSSIBLE_SHARE_EXPECTATION: `기회가 ${totalChance}번 남았어요!\n링크 공유 / 기대평 작성으로 추가 재도전 기회를 얻으세요!`,
+    POSSIBLE_EXPECTATION: `기회가 ${totalChance}번 남았어요!\n기대평 작성으로 추가 재도전 기회를 얻으세요!`,
+    POSSIBLE_SHARE: `기회가 ${totalChance}번 남았어요!\n링크 공유로 추가 재도전 기회를 얻으세요!`,
+    POSSIBLE: `기회가 ${totalChance}번 남았어요!`,
+    IMPOSSIBLE_SHARE_EXPECTATION: `이벤트 참여 기회가 모두 소진되었어요.\n링크 공유 / 기대평 작성으로 추가 재도전 기회를 얻으세요!`,
+    IMPOSSIBLE_EXPECTATION: `이벤트 참여 기회가 모두 소진되었어요.\n기대평 작성으로 추가 재도전 기회를 얻으세요!`,
+    IMPOSSIBLE_SHARE: `이벤트 참여 기회가 모두 소진되었어요.\n링크 공유로 추가 재도전 기회를 얻으세요!`,
+    IMPOSSIBLE: `이벤트 참여 기회가 모두 소진되었어요.\n8시간 후, 2번의 이벤트 참여 기회를 추가로 얻을 수 있어요!`,
+  };
+
+  const key = [
+    totalChance > 0 ? "POSSIBLE" : "IMPOSSIBLE",
+    expectationChance === -1 ? "EXPECTATION" : "",
+    shareChance === -1 ? "SHARE" : "",
+  ]
+    .filter(Boolean)
+    .join("_") as keyof messageType;
+
+  return messages[key];
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#175-drawing-chance

### 💡 작업동기
- 드로잉 기회부분을 포함한 디테일 추가

### 🔑 주요 변경사항
- 이벤트 버튼에 disabled, event_end 로직 추가
- 기회에 따른 메시지, 버튼 클릭 로직 수정
- 업데이트 날짜 수정
- useDrawingChance에서 서비스 로직 분리
- 유틸 함수 추가

### 🏞 스크린샷

> 기회 없을 때
<img width="427" alt="image" src="https://github.com/user-attachments/assets/ad22e624-e178-4a0d-8991-757b8a7116ca">

> 기존 기회 + 충전 가능한 기회가 1회일 때
<img width="359" alt="image" src="https://github.com/user-attachments/assets/806021a8-7415-46ea-8110-8e3bd75c04e0">

> 기존 기회 + 충전 가능한 기회가 2회일 때
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c8617ba4-a3b3-4172-9a17-c5804e6acccf">

> 기회 1, 링크 공유, 기대평 작성 가능할 때
<img width="484" alt="image" src="https://github.com/user-attachments/assets/5bdef9e8-2e60-43b3-99ea-4ade794404a4">

> 기회 1, 링크 공유만 가능할 때
<img width="355" alt="image" src="https://github.com/user-attachments/assets/cfd233df-96ab-44d0-bd2f-15a02320bedb">

> 기회 1, 링크 공유 x, 기대평 작성 x 
<img width="183" alt="image" src="https://github.com/user-attachments/assets/54abe205-4281-4eed-b54b-aa8a67069328">

> 기회 0, 링크 공유, 기대평 작성 가능할 때
<img width="485" alt="image" src="https://github.com/user-attachments/assets/ebbd0350-3e0a-4ce6-aca8-96090c969847">

> 기회 0, 링크 공유 x, 기대평 작성 x 
<img width="498" alt="image" src="https://github.com/user-attachments/assets/9e0e85ba-7569-4536-9716-ffbd611aca0a">

### 관련 이슈
- closed: #175 
