### PR TITLE
로그인하지 않았을 때의 드로잉 랜딩 페이지를 처리합니다.

### DIFF
--- a/strawberry/src/data/queries/eventUser/useEventUserInfoQuery.tsx
+++ b/strawberry/src/data/queries/eventUser/useEventUserInfoQuery.tsx
@@ -2,8 +2,11 @@ import { useQuery } from "react-query";
 
 import network from "../../config/network";
 import { EventUserInfo } from "../../entities/EventUserInfo";
+import { useGlobalState } from "../../../core/hooks/useGlobalState";
 
 export function useEventUserInfoQuery() {
+  const { isLogin } = useGlobalState();
+
   const getEventUserInfo = async () => {
     return await network.get<EventUserInfo>("eventuser/info", {
       queryParams: {
@@ -15,6 +18,7 @@ export function useEventUserInfoQuery() {
   const query = useQuery<EventUserInfo, Error>({
     queryKey: ["eventUserInfo"],
     queryFn: getEventUserInfo,
+    enabled: !!isLogin,
   });
 
   return query;

--- a/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
@@ -7,20 +7,20 @@ import useDrawingBanner from "../../hooks/useDrawingBanner";
 import DrawingChance from "./DrawingChance";
 
 function DrawingBanner() {
-  const { possibleChance, isFinished, landData, handleEventClick } =
+  const { possibleChance, isFinished, landData, handleEventClick, isLogin } =
     useDrawingBanner();
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">
       <BannerImage src={landData?.bannerImgUrl}></BannerImage>
       <BannerContentWrapper>
-        {!isFinished && <DrawingChance />}
+        {!isFinished && isLogin && <DrawingChance />}
         <EventButton
           type="DRAWING"
           status={
             isFinished
               ? "EVENT_END"
-              : possibleChance === 0
+              : possibleChance === 0 && isLogin
                 ? "DISABLED"
                 : "DEFAULT"
           }

--- a/strawberry/src/pages/drawingLanding/components/drawingRank/MyDrawingScore.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingRank/MyDrawingScore.tsx
@@ -13,7 +13,7 @@ function MyDrawingScore() {
         내 최고 점수
       </Label>
       <Label $token="Title3Medium" color={theme.Color.TextIcon.strong}>
-        {Number(eventUserData?.gameScore.toFixed(1))}점
+        {eventUserData?.gameScore.toFixed(1) || "-  "}점
       </Label>
     </MyScore>
   );

--- a/strawberry/src/pages/drawingLanding/hooks/useDrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/hooks/useDrawingBanner.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useCheckLogin } from "../../../core/hooks/useCheckLogin";
 import { useDrawingLandingState } from "./useDrawingLandingState";
 import { getChanceFromLastTime } from "../services/getChanceFromLastTime";
+import { useGlobalState } from "../../../core/hooks/useGlobalState";
 
 function useDrawingBanner() {
   const [possibleChance, setPossibleChance] = useState<number>(0);
@@ -11,6 +12,7 @@ function useDrawingBanner() {
     useDrawingLandingState();
   const navigate = useNavigate();
   const checkLogin = useCheckLogin();
+  const { isLogin } = useGlobalState();
 
   const isFinished =
     landData?.endAt && new Date(landData.endAt).getTime() < Date.now();
@@ -37,6 +39,7 @@ function useDrawingBanner() {
     isFinished,
     landData,
     handleEventClick,
+    isLogin,
   };
 }
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#213-not-login-drawing-landing

### 💡 작업동기
- 로그인하지 않았을 때의 드로잉 랜딩 페이지를 처리

### 🔑 주요 변경사항
- EventInfoQuery에 로그인하지 않았을 경우 패치하지 않는 속성 추가 (오류 해결)
- 로그인하지 않았을 경우 이벤트 버튼 활성화, infoMsg 숨김
- 로그인하지 않았을 경우 내 최고 점수 "-"로 처리

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d4591599-8d31-4fce-8630-3e22544e7524">
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/61c9e052-c834-4916-8d17-ad1f639b04d2">


### 관련 이슈
- closed: #213 
