### PR TITLE
랜딩페이지에서 퀴즈 remainTime이 0일 때를 처리합니다.

### DIFF
--- a/strawberry/src/pages/landing/components/landingEvent/CountdownTimer.tsx
+++ b/strawberry/src/pages/landing/components/landingEvent/CountdownTimer.tsx
@@ -16,7 +16,14 @@ const CountdownTimer = ({ initialTime }: CountdownTimerProps) => {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      setTime((prevTime) => prevTime - 1);
+      setTime((prevTime) => {
+        if (prevTime > 0) {
+          return prevTime - 1;
+        } else {
+          clearInterval(intervalId);
+          return 0;
+        }
+      });
     }, 1000);
 
     return () => clearInterval(intervalId);
@@ -25,7 +32,9 @@ const CountdownTimer = ({ initialTime }: CountdownTimerProps) => {
   const { days, hours, minutes, seconds } = convertSeconds(time);
 
   const formatTime = () => {
-    return `${days}일 ${hours.toString().padStart(2, "0")} : ${minutes.toString().padStart(2, "0")} : ${seconds.toString().padStart(2, "0")}`;
+    return `${days}일 ${hours.toString().padStart(2, "0")} : ${minutes
+      .toString()
+      .padStart(2, "0")} : ${seconds.toString().padStart(2, "0")}`;
   };
 
   return <TimeDisplay>{formatTime()}</TimeDisplay>;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#216-landing-quiz-remain-zero

### 💡 작업동기
- 퀴즈 오픈까지의 시간이 0일 때의 버그를 수정

### 🔑 주요 변경사항
- 남은 시간이 0일 때 처리

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/27b39060-f606-46c3-8a10-4028efbf8131">

### 관련 이슈
- closed: #216 
