### PR TITLE
선착순 퀴즈 제출 시 pending 상태에서의 모달을 추가합니다. 

### DIFF
--- a/strawberry/src/core/contexts/globalContext.tsx
+++ b/strawberry/src/core/contexts/globalContext.tsx
@@ -12,7 +12,7 @@ export type UserData = {
   name: string;
 };
 
-type ModalCategoryType = "TWO_BUTTON" | "ONE_BUTTON" | null;
+type ModalCategoryType = "TWO_BUTTON" | "ONE_BUTTON" | "PROGRESS" | null;
 
 type ModalPropsType = {
   title?: string;

--- a/strawberry/src/pages/common/components/modal/Modal.tsx
+++ b/strawberry/src/pages/common/components/modal/Modal.tsx
@@ -4,6 +4,7 @@ import useModal from "../../hooks/useModal";
 
 import TwoButtonModal from "./TwoButtonModal";
 import OneButtonModal from "./OneButtonModal";
+import ProgressModal from "./ProgressModal";
 
 export const Modal = () => {
   const { isModalOpen, modalCategory } = useModal();
@@ -15,6 +16,7 @@ export const Modal = () => {
           <ModalWrapper>
             {modalCategory === "TWO_BUTTON" && <TwoButtonModal />}
             {modalCategory === "ONE_BUTTON" && <OneButtonModal />}
+            {modalCategory === "PROGRESS" && <ProgressModal />}
           </ModalWrapper>
         </ModalBackground>
       )}

--- a/strawberry/src/pages/common/components/modal/ProgressModal.tsx
+++ b/strawberry/src/pages/common/components/modal/ProgressModal.tsx
@@ -1,0 +1,59 @@
+import { theme, Wrapper, Label } from "../../../../core/design_system";
+
+import { useGlobalDispatch } from "../../../../core/hooks/useGlobalDispatch";
+
+import ModalButton from "../buttons/ModalButton";
+import SubmitProgress from "../progress/SubmitProgress";
+
+function ProgressModal() {
+  const globalDispatch = useGlobalDispatch();
+
+  function closeModal() {
+    globalDispatch?.({ type: "CLOSE_MODAL" });
+  }
+
+  return (
+    <>
+      <Wrapper
+        width="100%"
+        display="flex"
+        $flexdirection="column"
+        $alignitems="center"
+      >
+        <Label $token="Title1Medium" color={theme.Color.Primary.normal}>
+          답변을 제출하고 있습니다.
+        </Label>
+        <Wrapper $margin="24px 0 0 0">
+          <SubmitProgress limitTime={5} />
+        </Wrapper>
+        <Label
+          width="100%"
+          $margin="24px 0 0 0"
+          $token="Heading2Regular"
+          color={theme.Color.TextIcon.sub}
+          $textalign="center"
+        >
+          {
+            "현재 답변을 제출하고 있습니다!\n잠시만 기다리시면 답변 제출이 완료됩니다."
+          }
+        </Label>
+        <Wrapper
+          width="100%"
+          display="flex"
+          $flexdirection="row"
+          $justifycontent="space-between"
+          $margin="48px 0 0 0"
+          $gap="15px"
+        >
+          <ModalButton
+            modalType="WHITE_LARGE"
+            content="닫기"
+            onClick={closeModal}
+          />
+        </Wrapper>
+      </Wrapper>
+    </>
+  );
+}
+
+export default ProgressModal;

--- a/strawberry/src/pages/common/components/progress/SubmitProgress.tsx
+++ b/strawberry/src/pages/common/components/progress/SubmitProgress.tsx
@@ -1,27 +1,13 @@
-import { useState, useEffect } from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
-const SubmitProgress = ({ limitTime }) => {
-  const [progress, setProgress] = useState(0);
-  const [isMounted, setIsMounted] = useState(true);
+import { useSubmitProgress } from "../../hooks/useSubmitProgress";
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setProgress((prevProgress) => {
-        if (prevProgress >= 100) {
-          setIsMounted(false);
-          setTimeout(() => {
-            setProgress(0);
-            setIsMounted(true);
-          }, 100);
-          return prevProgress;
-        }
-        return prevProgress + 100 / limitTime;
-      });
-    }, 1000); // 1초마다 업데이트
+interface SubmitProgressProps {
+  limitTime: number;
+}
 
-    return () => clearInterval(interval);
-  }, [limitTime]);
+const SubmitProgress = ({ limitTime }: SubmitProgressProps) => {
+  const { progress, isMounted } = useSubmitProgress(limitTime);
 
   return (
     <SubmitProgressContainer>
@@ -45,10 +31,8 @@ const SubmitProgressContainer = styled.div`
   overflow: hidden;
 `;
 
-const SubmitProgressFill = styled.div`
+const SubmitProgressFill = styled.div<{ progress: number }>`
   height: 100%;
   background-color: #002c5f;
-  ${({ progress }) => css`
-    transition: width 1s linear;
-  `}
+  transition: width 1s linear;
 `;

--- a/strawberry/src/pages/common/hooks/useSubmitProgress.tsx
+++ b/strawberry/src/pages/common/hooks/useSubmitProgress.tsx
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+
+export function useSubmitProgress(limitTime: number) {
+  const [progress, setProgress] = useState(0);
+  const [isMounted, setIsMounted] = useState(true);
+
+  useEffect(() => {
+    setProgress(100 / limitTime);
+
+    const interval = setInterval(() => {
+      setProgress((prevProgress) => {
+        if (prevProgress >= 100) {
+          setIsMounted(false);
+          setTimeout(() => {
+            setProgress(0);
+            setIsMounted(true);
+          }, 100);
+          return prevProgress;
+        }
+        return prevProgress + 100 / limitTime;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [limitTime]);
+
+  return { progress, isMounted };
+}

--- a/strawberry/src/pages/quizPlay/hooks/logics/useQuizPlayPage.tsx
+++ b/strawberry/src/pages/quizPlay/hooks/logics/useQuizPlayPage.tsx
@@ -1,9 +1,33 @@
-import { useQuizPlayState } from "../useQuizPlayState";
+import { useEffect } from "react";
+
+import { useGlobalDispatch } from "../../../../core/hooks/useGlobalDispatch";
 
 import { useQuizPlayMutation } from "../../../../data/queries/quiz/useQuizPlayMutation";
 
+import { useQuizPlayState } from "../useQuizPlayState";
+
 function useQuizPlayPage() {
-  const { mutate: postQuiz } = useQuizPlayMutation();
+  const { mutate: postQuiz, isLoading } = useQuizPlayMutation();
+  const globalDispatch = useGlobalDispatch();
+
+  useEffect(() => {
+    let timeoutId: number | undefined;
+
+    if (isLoading) {
+      timeoutId = setTimeout(() => {
+        globalDispatch?.({
+          type: "OPEN_MODAL",
+          modalCategory: "PROGRESS",
+          modalProps: {},
+        });
+      }, 200); // 0.2초 안에 결과가 나오면 로딩창 안 보여줌
+    } else {
+      clearTimeout(timeoutId);
+    }
+
+    return () => clearTimeout(timeoutId);
+  }, [isLoading, globalDispatch]);
+
   const {
     description,
     question,


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#218-add-Progress-modal

### 💡 작업동기
- 선착순 퀴즈 이벤트에서 답변 제출 결과를 기다릴 모달 추가

### 🔑 주요 변경사항
- ProgressModal 구현
- modal type에 추가
- 답변 제출 mutation의 isLoading을 기반으로 modal open (0.2초 안에 응답이 오면 로딩 모달 띄우지 않음)
- progress transition 로직 수정 (렌더링 직후 바로 게이지가 차도록 수정)

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/80c3647c-fd40-4e30-87ff-5b4edf9a4549">

### 관련 이슈
- closed: #218 
