### PR TITLE
퀴즈 플레이 input 이외의 element 클릭 시 hightlight를 해제합니다. 

### DIFF
--- a/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
+++ b/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
@@ -16,6 +16,7 @@ const CardInput = (props: CardInputProps) => {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
 
   const { isModalOpen } = useGlobalState();
   const { answer: content } = useQuizPlayState();
@@ -81,10 +82,15 @@ const CardInput = (props: CardInputProps) => {
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         maxLength={length}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
       />
       <VisibleContent>
         {Array.from({ length }).map((_, index) => (
-          <CharacterBox key={index} isHighlighted={index === highlightedIndex}>
+          <CharacterBox
+            key={index}
+            isHighlighted={isFocused && index === highlightedIndex}
+          >
             <Character isFilled={Boolean(content[index])}>
               {content[index] || placeholder[index]}
             </Character>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#226-blur-highlight

### 💡 작업동기
- focus되지 않은 상태에서 hightlight를 해제합니다.

### 🔑 주요 변경사항
- isFocused 변수를 통해 관리

### 🏞 스크린샷

> input 이외의 element 클릭 시 highlight 해제
<img width="1693" alt="image" src="https://github.com/user-attachments/assets/29f821c2-08cf-4010-bdb3-015886084bc4">

> 정답 제출 시 focus 해제 되며 highlight가 해제
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/86967c8e-2b0a-469e-8189-77febbe81686">


### 관련 이슈
- closed: #226 
