### PR TITLE
퀴즈 랜딩 페이지의 오늘의 문제, 이벤트 참여 버튼 디테일을 추가합니다.

### DIFF
--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
@@ -31,8 +31,10 @@ function QuizBanner() {
         >
           <EventButton
             type="QUIZ"
-            status="DEFAULT"
-            content="이벤트 참여하기"
+            status={data?.valid ? "DEFAULT" : "EVENT_END"}
+            content={
+              data?.valid ? "이벤트 참여하기" : "이벤트가 종료되었습니다."
+            }
             onClick={handleEventClick}
           ></EventButton>
         </Wrapper>

--- a/strawberry/src/pages/quizLanding/components/quizOpen/QuizEventEnd.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizOpen/QuizEventEnd.tsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import { theme, Label } from "../../../../core/design_system";
+
+function QuizEventEnd() {
+  return (
+    <>
+      <StyledDiv>
+        <Label $token="Display1Medium" color={theme.Color.Common.white}>
+          모든 이벤트가 종료되었습니다.
+        </Label>
+      </StyledDiv>
+    </>
+  );
+}
+
+export default QuizEventEnd;
+
+const StyledDiv = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: ${({ theme }) => theme.Color.Dimmer.default};
+  backdrop-filter: blur(2px);
+`;

--- a/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpen.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpen.tsx
@@ -6,6 +6,7 @@ import { formatEventDateTime } from "../../../../core/utils";
 import { useQuizLandingState } from "../../hooks";
 
 import QuizOpenStep from "./QuizOpenStep";
+import QuizEventEnd from "./QuizEventEnd";
 
 function QuizOpen() {
   const { quizLandingData } = useQuizLandingState();
@@ -21,6 +22,7 @@ function QuizOpen() {
         current={quizLandingData?.quizSequence ?? 0}
       />
       <QuestionWrapper>
+        {!quizLandingData?.valid && <QuizEventEnd />}
         <Label
           width="100%"
           $textalign="center"
@@ -63,6 +65,7 @@ const QuestionWrapper = styled.div`
   padding: 33px 28px;
   background-color: ${({ theme }) => theme.Color.TextIcon.reverse};
   box-shadow: 4px 4px 20px 0px rgba(0, 0, 0, 0.1);
+  position: relative;
 `;
 
 const HintWrapper = styled.div`

--- a/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpenStep.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpenStep.tsx
@@ -14,7 +14,11 @@ function QuizOpenStep(props: QuizOpenStepProps) {
     <Wrapper display="flex" height="38px">
       {Array.from({ length: total - 1 }, (_, index) => (
         <Wrapper display="flex" $alignitems="center">
-          <Step key={index} $isSelected={index + 1 === current}>
+          <Step
+            key={index}
+            $isFinished={index + 1 < current}
+            $isSelected={index + 1 === current}
+          >
             {index + 1}차 오픈
           </Step>
           <DotLine $backgroundcolor={theme.Color.Neutral.neutral90} />
@@ -29,6 +33,7 @@ export default QuizOpenStep;
 
 interface StepStyle {
   $isSelected: boolean;
+  $isFinished: boolean;
 }
 
 const Step = styled.div<StepStyle>`
@@ -54,5 +59,12 @@ const Step = styled.div<StepStyle>`
       color: ${theme.Color.TextIcon.reverse};
       box-shadow: 4px 2px 6px 0px rgba(0, 0, 0, 0.18);
       background-color: ${theme.Color.Neutral.neutral22};
+    `}
+  ${({ $isFinished, theme }) =>
+    $isFinished &&
+    `
+      color: ${theme.Color.TextIcon.disable};
+      box-shadow: 4px 2px 6px 0px rgba(0, 0, 0, 0.18);
+      background-color: ${theme.Color.Neutral.neutral60};
     `}
 `;

--- a/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpenStep.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpenStep.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 import { DotLine, Wrapper, theme } from "../../../../core/design_system";
+import useQuizOpenStep from "../../hooks/useQuizOpenStep";
 
 interface QuizOpenStepProps {
   total: number;
@@ -9,6 +10,7 @@ interface QuizOpenStepProps {
 
 function QuizOpenStep(props: QuizOpenStepProps) {
   const { total, current } = props;
+  const { isOpened, isClosed } = useQuizOpenStep();
 
   return (
     <Wrapper display="flex" height="38px">
@@ -16,10 +18,12 @@ function QuizOpenStep(props: QuizOpenStepProps) {
         <Wrapper display="flex" $alignitems="center">
           <Step
             key={index}
-            $isFinished={index + 1 < current}
-            $isSelected={index + 1 === current}
+            $isFinished={isClosed(index, current)}
+            $isSelected={isOpened(index, current)}
           >
-            {index + 1}차 오픈
+            {isClosed(index, current)
+              ? `${index + 1}차 마감`
+              : `${index + 1}차 오픈`}
           </Step>
           <DotLine $backgroundcolor={theme.Color.Neutral.neutral90} />
         </Wrapper>

--- a/strawberry/src/pages/quizLanding/hooks/useQuizOpenStep.tsx
+++ b/strawberry/src/pages/quizLanding/hooks/useQuizOpenStep.tsx
@@ -1,0 +1,18 @@
+function useQuizOpenStep() {
+  function isOpened(index: number, current: number) {
+    if (index + 1 === current) return true;
+    return false;
+  }
+
+  function isClosed(index: number, current: number) {
+    if (index + 1 < current) return true;
+    return false;
+  }
+
+  return {
+    isOpened,
+    isClosed,
+  };
+}
+
+export default useQuizOpenStep;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#174-quiz-landing-detail

### 💡 작업동기
- 퀴즈 랜딩 페이지의 디테일 추가

### 🔑 주요 변경사항
- 진행 중인 퀴즈에 따른 ui 반영
- 이벤트 종료 시에 보여줄 component 구현 후 추가
- 이벤트 종료 시 event_end 버튼

### 🏞 스크린샷
<img width="1716" alt="image" src="https://github.com/user-attachments/assets/b6af9b32-9a9c-4fba-9e4e-cf861db0a975">

> 백엔드 quizSequence 변경하면 step 제대로 반영
<img width="1718" alt="image" src="https://github.com/user-attachments/assets/42ebff3a-67c8-47e2-85f7-5f054694deb5">

<img width="1711" alt="image" src="https://github.com/user-attachments/assets/af104b62-bfb4-435b-8fc0-fdfaa2222188">


### 관련 이슈
- closed: #174 
