### PR TITLE
이벤트에 처음 참가하는 유저가 정상적으로 드로잉게임을 진행할 수 있도록 합니다.

### DIFF
--- a/strawberry/src/data/queries/drawing/useDrawingRankQuery.tsx
+++ b/strawberry/src/data/queries/drawing/useDrawingRankQuery.tsx
@@ -3,16 +3,21 @@ import { useQuery } from "react-query";
 import network from "../../config/network";
 import { DrawingRank } from "../../entities/DrawingRank";
 
-export function useDrawingRankQuery() {
+interface UseDrawingRankQueryProps {
+  subEventId: number | undefined;
+}
+
+export function useDrawingRankQuery({ subEventId }: UseDrawingRankQueryProps) {
   const getDrawingRank = async () => {
     return await network.get<DrawingRank[]>("lottery/drawing/rank", {
-      queryParams: { subEventId: "4" },
+      queryParams: { subEventId: subEventId },
     });
   };
 
   const query = useQuery<DrawingRank[], Error>({
     queryKey: ["drawingRank"],
     queryFn: getDrawingRank,
+    enabled: false,
   });
 
   return query;

--- a/strawberry/src/data/queries/eventUser/useEventUserInfoQuery.tsx
+++ b/strawberry/src/data/queries/eventUser/useEventUserInfoQuery.tsx
@@ -4,21 +4,34 @@ import network from "../../config/network";
 import { EventUserInfo } from "../../entities/EventUserInfo";
 import { useGlobalState } from "../../../core/hooks/useGlobalState";
 
-export function useEventUserInfoQuery() {
+import { CustomError } from "../../config/customError";
+
+interface UseEventUserInfoQueryProps {
+  subEventId: number | undefined;
+}
+
+export function useEventUserInfoQuery({
+  subEventId,
+}: UseEventUserInfoQueryProps) {
   const { isLogin } = useGlobalState();
 
   const getEventUserInfo = async () => {
     return await network.get<EventUserInfo>("eventuser/info", {
       queryParams: {
-        subEventId: "4",
+        subEventId: subEventId,
       },
     });
   };
 
-  const query = useQuery<EventUserInfo, Error>({
+  const query = useQuery<EventUserInfo, CustomError>({
     queryKey: ["eventUserInfo"],
     queryFn: getEventUserInfo,
-    enabled: !!isLogin,
+    enabled: !!isLogin && !!subEventId,
+    onError(err) {
+      if (err.status !== 404) {
+        alert(err.message);
+      }
+    },
   });
 
   return query;

--- a/strawberry/src/data/queries/eventUser/useEventUserInfoQuery.tsx
+++ b/strawberry/src/data/queries/eventUser/useEventUserInfoQuery.tsx
@@ -28,7 +28,7 @@ export function useEventUserInfoQuery({
     queryFn: getEventUserInfo,
     enabled: !!isLogin && !!subEventId,
     onError(err) {
-      if (err.status !== 404) {
+      if (![401, 404].includes(err.status ?? 0)) {
         alert(err.message);
       }
     },

--- a/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingBanner.tsx
@@ -7,20 +7,26 @@ import useDrawingBanner from "../../hooks/useDrawingBanner";
 import DrawingChance from "./DrawingChance";
 
 function DrawingBanner() {
-  const { possibleChance, isFinished, landData, handleEventClick, isLogin } =
-    useDrawingBanner();
+  const {
+    possibleChance,
+    isFinished,
+    isFirst,
+    landData,
+    handleEventClick,
+    isLogin,
+  } = useDrawingBanner();
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">
       <BannerImage src={landData?.bannerImgUrl}></BannerImage>
       <BannerContentWrapper>
-        {!isFinished && isLogin && <DrawingChance />}
+        {!isFinished && <DrawingChance isLogin={isLogin} isFirst={isFirst} />}
         <EventButton
           type="DRAWING"
           status={
             isFinished
               ? "EVENT_END"
-              : possibleChance === 0 && isLogin
+              : possibleChance === 0 && isLogin && !isFirst
                 ? "DISABLED"
                 : "DEFAULT"
           }

--- a/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingChance.tsx
+++ b/strawberry/src/pages/drawingLanding/components/drawingBanner/DrawingChance.tsx
@@ -3,8 +3,14 @@ import { theme, Wrapper, Label } from "../../../../core/design_system";
 import { useDrawingChance } from "../../hooks/useDrawingChance";
 import { useDrawingLandingState } from "../../hooks/useDrawingLandingState";
 
-function DrawingChance() {
+interface DrawingChanceProps {
+  isLogin: boolean;
+  isFirst: boolean;
+}
+
+function DrawingChance({ isLogin, isFirst }: DrawingChanceProps) {
   const { eventUserData } = useDrawingLandingState();
+
   const text = useDrawingChance(eventUserData);
 
   return (
@@ -21,7 +27,11 @@ function DrawingChance() {
         color={theme.Color.TextIcon.reverse}
         $textalign="center"
       >
-        {text}
+        {!isLogin
+          ? "자동차 따라그리기에 도전해보세요!"
+          : isFirst
+            ? "첫 게임에 도전해보세요!"
+            : text}
       </Label>
     </Wrapper>
   );

--- a/strawberry/src/pages/drawingLanding/hooks/useDrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/hooks/useDrawingBanner.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useCheckLogin } from "../../../core/hooks/useCheckLogin";
-import { useDrawingLandingState } from "./useDrawingLandingState";
-import { getChanceFromLastTime } from "../services/getChanceFromLastTime";
 import { useGlobalState } from "../../../core/hooks/useGlobalState";
+import { useCheckLogin } from "../../../core/hooks/useCheckLogin";
+
+import { useDrawingLandingState } from "./useDrawingLandingState";
+
+import { getChanceFromLastTime } from "../services/getChanceFromLastTime";
 
 function useDrawingBanner() {
   const [possibleChance, setPossibleChance] = useState<number>(0);
@@ -13,6 +15,8 @@ function useDrawingBanner() {
   const navigate = useNavigate();
   const checkLogin = useCheckLogin();
   const { isLogin } = useGlobalState();
+
+  const isFirst = eventData === undefined ? true : false;
 
   const isFinished =
     landData?.endAt && new Date(landData.endAt).getTime() < Date.now();
@@ -40,6 +44,7 @@ function useDrawingBanner() {
     landData,
     handleEventClick,
     isLogin,
+    isFirst,
   };
 }
 

--- a/strawberry/src/pages/drawingLanding/hooks/useDrawingLandingData.tsx
+++ b/strawberry/src/pages/drawingLanding/hooks/useDrawingLandingData.tsx
@@ -6,11 +6,24 @@ import {
   useEventUserInfoQuery,
   useDrawingLandingQuery,
 } from "../../../data/queries";
+import { useDrawingLandingState } from "./useDrawingLandingState";
 
 export function useDrawingLandingData() {
+  const state = useDrawingLandingState();
+
   const { data: landData } = useDrawingLandingQuery();
-  const { data: rankData } = useDrawingRankQuery();
-  const { data: eventUserData } = useEventUserInfoQuery();
+  const { data: rankData, refetch: fetchRank } = useDrawingRankQuery({
+    subEventId: state.drawingLandingData?.subEventId,
+  });
+  const { data: eventUserData, refetch: fetchEventInfo } =
+    useEventUserInfoQuery({ subEventId: state.drawingLandingData?.subEventId });
+
+  useEffect(() => {
+    if (state.drawingLandingData?.subEventId) {
+      fetchRank();
+      fetchEventInfo();
+    }
+  }, [state.drawingLandingData?.subEventId]);
 
   const dispatch = useDrawingLandingDispatch();
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#233-drawing-init

### 💡 작업동기
- 게임에 처음 참여하는 유저가 eventUserInfo를 불러오는 과정에 문제가 생겨 이를 해결 후 처음 게임 참여 경우 추가

### 🔑 주요 변경사항
- queery들의 실행 순서 추가
- useEventUserQuery에서 404일 시 pass
- eventUserData를 통한 isFrist 변수를 통해 처음 참여 유저인지 판별
- 해당 케이스에 대한 문구, 버튼 활성화 로직 추가

### 🏞 스크린샷
> 처음 게임에 참여하는 경우
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/6fa459bb-7dc4-41ea-b705-03c99a1355c2">

> 로그인하지 않은 경우
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/6978a391-93b3-4c89-b9f3-6c1764e76c8a">


### 관련 이슈
- closed: #233 
