### PR TITLE
중복 회원가입 시 로직을 처리합니다.

### DIFF
--- a/strawberry/src/data/queries/user/useLoginCallbackQuery.tsx
+++ b/strawberry/src/data/queries/user/useLoginCallbackQuery.tsx
@@ -3,9 +3,16 @@ import { useQuery } from "react-query";
 import network from "../../config/network";
 import { Oauth } from "../../entities/Oauth";
 
+import { CustomError } from "../../config/customError";
+import { useNavigate } from "react-router-dom";
+import useDuplicatedSignUpModal from "../../../pages/login/hooks/useDuplicatedSignUpModal";
+
 export function useLoginCallbackQuery(type: string, code: string) {
+  const navigate = useNavigate();
+  const showModal = useDuplicatedSignUpModal();
+
   const getLoginCallback = async () => {
-    return await network.get<Oauth>(`oauth2/${type}/callback`, {
+    return network.get<Oauth>(`oauth2/${type}/callback`, {
       queryParams: {
         code: code,
         state: type,
@@ -13,9 +20,18 @@ export function useLoginCallbackQuery(type: string, code: string) {
     });
   };
 
-  const query = useQuery<Oauth, Error>({
+  const query = useQuery<Oauth, CustomError>({
     queryKey: ["oauth"],
     queryFn: getLoginCallback,
+    retry: 0,
+    onError(err) {
+      if (err.status === 409) {
+        navigate("/login");
+        showModal();
+      } else {
+        alert(err.message);
+      }
+    },
   });
 
   return query;

--- a/strawberry/src/pages/login/hooks/useDuplicatedSignUpModal.tsx
+++ b/strawberry/src/pages/login/hooks/useDuplicatedSignUpModal.tsx
@@ -1,0 +1,17 @@
+import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
+
+function useDuplicatedSignUpModal() {
+  const dispatch = useGlobalDispatch();
+
+  return () =>
+    dispatch?.({
+      type: "OPEN_MODAL",
+      modalCategory: "ONE_BUTTON",
+      modalProps: {
+        info: "이미 가입한 이력이 있습니다.",
+        primaryBtnContent: "확인",
+      },
+    });
+}
+
+export default useDuplicatedSignUpModal;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#232-duplicated-sign-up

### 💡 작업동기
- 중복 회원가입(sns 로그인) 시를 처리합니다.

### 🔑 주요 변경사항
- useLoginRedirectQuery의 error 로직 수정
- useDuplicatedSignUpModal 추가

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/927a107c-6140-4587-8db4-d3ceeb561ee6">

### 관련 이슈
- closed: #232 
