### PR TITLE
퀴즈 랜딩 페이지에서 모든 이벤트의 기간이 끝났을 때를 처리합니다.

### DIFF
--- a/strawberry/src/pages/common/components/modal/OneButtonModal.tsx
+++ b/strawberry/src/pages/common/components/modal/OneButtonModal.tsx
@@ -13,8 +13,16 @@ function OneButtonModal() {
     globalDispatch?.({ type: "CLOSE_MODAL" });
   }
 
-  const { title, imgPath, info, primaryBtnContent, onPrimaryBtnClick, enter } =
-    useGlobalState().modalProps || {};
+  const {
+    title,
+    imgPath,
+    info,
+    whiteBtnContent,
+    onWhiteBtnClick,
+    primaryBtnContent,
+    onPrimaryBtnClick,
+    enter,
+  } = useGlobalState().modalProps || {};
 
   useEffect(() => {
     if (enter) {
@@ -64,11 +72,20 @@ function OneButtonModal() {
           $margin="48px 0 0 0"
           $gap="15px"
         >
-          <ModalButton
-            modalType="PRIMARY_SMALL"
-            content={primaryBtnContent || ""}
-            onClick={onPrimaryBtnClick || closeModal}
-          />
+          {primaryBtnContent && (
+            <ModalButton
+              modalType="PRIMARY_SMALL"
+              content={primaryBtnContent || ""}
+              onClick={onPrimaryBtnClick || closeModal}
+            />
+          )}
+          {whiteBtnContent && (
+            <ModalButton
+              modalType="WHITE_SMALL"
+              content={whiteBtnContent || ""}
+              onClick={onWhiteBtnClick || closeModal}
+            />
+          )}
         </Wrapper>
       </Wrapper>
     </>

--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
@@ -1,23 +1,13 @@
 import styled from "styled-components";
-import { useNavigate } from "react-router-dom";
 
 import { Wrapper, EventButton } from "../../../../core/design_system";
-import { useCheckLogin } from "../../../../core/hooks/useCheckLogin";
 
-import { useQuizLandingState } from "../../hooks";
+import { useQuizBanner } from "../../hooks";
 
 import QuizBannerTimer from "./QuizBannerTimer";
 
 function QuizBanner() {
-  const navigate = useNavigate();
-  const checkLogin = useCheckLogin();
-  const { quizLandingData: data } = useQuizLandingState();
-
-  const handleEventClick = () => {
-    checkLogin(() => {
-      navigate(`/quiz/play/${data?.subEventId}`);
-    });
-  };
+  const { data, handleEventClick } = useQuizBanner();
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">

--- a/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpenStep.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizOpen/QuizOpenStep.tsx
@@ -28,7 +28,12 @@ function QuizOpenStep(props: QuizOpenStepProps) {
           <DotLine $backgroundcolor={theme.Color.Neutral.neutral90} />
         </Wrapper>
       ))}
-      <Step $isSelected={total === current}>{total}차 오픈</Step>
+      <Step
+        $isFinished={isClosed(total - 1, current)}
+        $isSelected={isOpened(total - 1, current)}
+      >
+        {isClosed(total - 1, current) ? `${total}차 마감` : `${total}차 오픈`}
+      </Step>
     </Wrapper>
   );
 }

--- a/strawberry/src/pages/quizLanding/hooks/useQuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/hooks/useQuizBanner.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useCheckLogin } from "../../../core/hooks/useCheckLogin";
+
+import { useGlobalDispatch } from "../../../core/hooks/useGlobalDispatch";
+import { useQuizLandingState } from "./useQuizLandingState";
+
+export const useQuizBanner = () => {
+  const navigate = useNavigate();
+  const checkLogin = useCheckLogin();
+  const dispatch = useGlobalDispatch();
+  const { quizLandingData: data } = useQuizLandingState();
+
+  const handleEventClick = () => {
+    checkLogin(() => {
+      navigate(`/quiz/play/${data?.subEventId}`);
+    });
+  };
+
+  useEffect(() => {
+    if (!data?.valid) {
+      dispatch({
+        type: "OPEN_MODAL",
+        modalCategory: "ONE_BUTTON",
+        modalProps: {
+          title: "이벤트 기간이 아닙니다",
+          info: "이벤트 기간을 확인해주세요.",
+          whiteBtnContent: "닫기",
+        },
+      });
+    }
+  }, [data?.valid, dispatch]);
+
+  return {
+    data,
+    handleEventClick,
+  };
+};


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#240-quiz-land-end

### 💡 작업동기
- 퀴즈 랜딩 페이지에서 이벤트가 모두 끝났을 때를 처리

### 🔑 주요 변경사항
- OneButtonModal에 whiteBtn 요소 추가
- openstep 로직 변경
- QuizBanner에 모달 로직 추가

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/804e2559-bc92-4244-9f0f-c49007726d1f">

### 관련 이슈
- closed: #240 