### PR TITLE
리액트 쿼리의 focus 전환 시 패치 로직을 수정합니다.

### DIFF
--- a/strawberry/src/App.tsx
+++ b/strawberry/src/App.tsx
@@ -10,6 +10,7 @@ const queryClient = new QueryClient({
       retry: 1,
       retryDelay: 1000,
       onError: handleQueryError,
+      refetchOnWindowFocus: false,
     },
     mutations: {
       onError: handleQueryError,

--- a/strawberry/src/data/queries/expectation/useExpectationListQuery.tsx
+++ b/strawberry/src/data/queries/expectation/useExpectationListQuery.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "react-query";
 
 import network from "../../config/network";
+import { CustomError } from "../../config/customError";
+
 import { ExpectationList } from "../../entities/ExpectationList";
 
 export function useExpectationListQuery(page: number) {
@@ -12,11 +14,18 @@ export function useExpectationListQuery(page: number) {
     });
   };
 
-  const query = useQuery<ExpectationList, Error>(
+  const query = useQuery<ExpectationList, CustomError>(
     ["expectationList", page],
     getExpectationList,
     {
       enabled: page !== undefined && page > 0,
+      onError(err) {
+        if (err.status !== 404) {
+          alert(err.message);
+        }
+      },
+      retry: 0,
+      refetchOnWindowFocus: true,
     },
   );
 

--- a/strawberry/src/data/queries/expectation/useExpectationPageQuery.tsx
+++ b/strawberry/src/data/queries/expectation/useExpectationPageQuery.tsx
@@ -11,6 +11,7 @@ export function useExpectationPageQuery() {
   const query = useQuery<ExpectationLand, Error>({
     queryKey: ["expectationPage"],
     queryFn: getExpectationPage,
+    refetchOnWindowFocus: true,
   });
 
   return query;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#250-refetch-on-window-focus

### 💡 작업동기
- 해당 속성이 default true인 상태에서 문제가 생겨 false로 고치고, 이 속성이 필요한 쿼리에서 true로 추가합니다.

### 🔑 주요 변경사항
- App 컴포넌트 내에 속성 false로 추가
- 해당 속성이 필요한 쿼리에서 추가

### 관련 이슈
- closed: #250 
