### PR TITLE
싼타페 보러가기 버튼에 nowrap 속성을 추가합니다.

### DIFF
--- a/strawberry/src/layout/components/header/CarIntroButton.tsx
+++ b/strawberry/src/layout/components/header/CarIntroButton.tsx
@@ -21,4 +21,5 @@ const StyledButton = styled(DefaultButton)`
   color: ${({ theme }) => theme.Color.TextIcon.sub};
   padding: 8px 20px;
   width: fit-content;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#249-visit-santafe-button

### 💡 작업동기
- 해당 버튼의 컨텐츠가 두줄로 나오는 현상이 있어 이를 해결합니다.

### 🔑 주요 변경사항
- white-space: nowrap 속성 추가

### 관련 이슈
- closed: #249 
