### PR TITLE
이벤트 기간이 맞지만 아니라는 모달이 뜨는 현상을 해결합니다.

### DIFF
--- a/strawberry/src/pages/quizLanding/hooks/useQuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/hooks/useQuizBanner.tsx
@@ -30,6 +30,7 @@ export const useQuizBanner = () => {
         },
       });
     }
+    return dispatch?.({ type: "CLOSE_MODAL" });
   }, [data?.valid, dispatch]);
 
   return {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#248-event-end-modal

### 💡 작업동기
- 이벤트 기간이 맞지만 아니라는 모달이 뜨는 현상을 수정합니다.

### 🔑 주요 변경사항
- useEffect 안에 return 문을 추가하여 해당 컴포넌트가 unmount 시에 clear modal

### 관련 이슈
- closed: #248 
