### PR TITLE
드로잉 랜딩 페이지에서 보너스 게임만 있을 때 기회가 제대로 조회되지 않는 현상을 해결합니다.

### DIFF
--- a/strawberry/src/pages/drawingLanding/hooks/useDrawingBanner.tsx
+++ b/strawberry/src/pages/drawingLanding/hooks/useDrawingBanner.tsx
@@ -25,7 +25,10 @@ function useDrawingBanner() {
     if (eventData) {
       setPossibleChance(
         Math.min(
-          getChanceFromLastTime(eventData?.lastChargeAt) + eventData?.chance,
+          getChanceFromLastTime(eventData?.lastChargeAt) +
+          eventData?.chance +
+          Math.max(0, eventData.expectationBonusChance) +
+          Math.max(0, eventData.shareBonusChance),
           2,
         ),
       );

--- a/strawberry/src/pages/drawingLanding/hooks/useDrawingChance.tsx
+++ b/strawberry/src/pages/drawingLanding/hooks/useDrawingChance.tsx
@@ -12,8 +12,12 @@ export function useDrawingChance(eventUserData: EventUserInfo | undefined) {
 
     let chance: number = eventUserData.chance ?? 0;
     const bonusChance: number =
-      (eventUserData.expectationBonusChance ?? 0) +
-      (eventUserData.shareBonusChance ?? 0);
+      (eventUserData.expectationBonusChance === -1
+        ? 0
+        : (eventUserData.expectationBonusChance ?? 0)) +
+      (eventUserData.shareBonusChance === -1
+        ? 0
+        : (eventUserData.shareBonusChance ?? 0));
 
     const lastPlayTime: string = eventUserData.lastChargeAt ?? "";
 
@@ -28,6 +32,8 @@ export function useDrawingChance(eventUserData: EventUserInfo | undefined) {
       } else {
         text = `${chance}회 도전할 수 있어요!`;
       }
+    } else if (bonusChance > 0) {
+      text = `보너스 기회로 ${bonusChance}회 도전할 수 있어요!`;
     } else {
       text = `${formatTimeUntilNextChance(lastPlayTime)}`;
     }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#257-drawing-landing-only-bonus

### 💡 작업동기
- 보너스 기회만 있는 상태에서 기회가 제대로 조회되지 않아 이를 해결합니다.

### 🔑 주요 변경사항
- Banner 로직 수정
- Chance 로직 수정

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/7f6adece-4746-44b8-8e60-8a71d7ba7aef">

### 관련 이슈
- closed: #257 
