### PR TITLE
문자열 submit 시에 blank로만 이루어진 경우를 해결합니다.

### DIFF
--- a/strawberry/src/core/utils/checkOnlyBlank.ts
+++ b/strawberry/src/core/utils/checkOnlyBlank.ts
@@ -1,0 +1,6 @@
+export function checkOnlyBlank(content: string) {
+  if (!content.trim().length) {
+    return true;
+  }
+  return false;
+}

--- a/strawberry/src/core/utils/index.tsx
+++ b/strawberry/src/core/utils/index.tsx
@@ -3,5 +3,13 @@ import { debounce } from "./debounce";
 import { throttle } from "./throttle";
 import formatEventDateTime from "./formatEventDateTime";
 import { scrollTop } from "./scrollTop";
+import { checkOnlyBlank } from "./checkOnlyBlank";
 
-export { convertSeconds, formatEventDateTime, debounce, throttle, scrollTop };
+export {
+  convertSeconds,
+  formatEventDateTime,
+  debounce,
+  throttle,
+  scrollTop,
+  checkOnlyBlank,
+};

--- a/strawberry/src/pages/expectation/components/ExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/components/ExpectationInput.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { Wrapper } from "../../../core/design_system";
 
 import useExpectationInput from "../hooks/logics/useExpectationInput";
+
 import SubmitButton from "./SubmitButton";
 
 function ExpectationInput() {

--- a/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/useExpectationInput.tsx
@@ -8,11 +8,12 @@ import { throttle } from "../../../../core/utils";
 import { useExpectationMutation } from "../../../../data/queries/expectation/useExpectationMutation";
 
 import useLengthValidation from "../useLengthValidation";
+import { checkOnlyBlank } from "../../../../core/utils";
 
 function useExpectationInput() {
   const { mutate: postExpectation, isSuccess } = useExpectationMutation();
   const [isFocused, setIsFocused] = useState(false);
-  const { content, handleChange } = useLengthValidation({
+  const { content, handleChange, resetContent } = useLengthValidation({
     initialContent: "",
     maxLength: 300,
   });
@@ -29,6 +30,12 @@ function useExpectationInput() {
   }, [isSuccess]);
 
   const handleSubmit = throttle()(() => {
+    if (checkOnlyBlank(content)) {
+      alert("공백만 제출할 수 없습니다.");
+      resetContent();
+      return;
+    }
+
     if (content.length === 0) {
       alert("내용을 입력해주세요.");
       return;

--- a/strawberry/src/pages/expectation/hooks/useLengthValidation.tsx
+++ b/strawberry/src/pages/expectation/hooks/useLengthValidation.tsx
@@ -22,7 +22,11 @@ function useLengthValidation({
     setContent(event.target.value);
   }
 
-  return { content, handleChange };
+  function resetContent() {
+    setContent("");
+  }
+
+  return { content, handleChange, resetContent };
 }
 
 export default useLengthValidation;

--- a/strawberry/src/pages/quizPlay/QuizPlayPage.tsx
+++ b/strawberry/src/pages/quizPlay/QuizPlayPage.tsx
@@ -3,6 +3,7 @@ import CardInput from "./components/quizInput/CardInput";
 import QuizBoard from "./components/quizBoard/QuizBoard";
 import useQuizPlayData from "./hooks/useQuizPlayData";
 import useQuizPlayPage from "./hooks/logics/useQuizPlayPage";
+import { checkOnlyBlank } from "../../core/utils";
 
 function QuizPlayPage() {
   useQuizPlayData();
@@ -15,9 +16,14 @@ function QuizPlayPage() {
     answer,
     subEventId,
     postQuiz,
+    showBlankModal,
   } = useQuizPlayPage();
 
   function handleSubmit() {
+    if (checkOnlyBlank(answer)) {
+      showBlankModal();
+      return;
+    }
     if (subEventId) {
       postQuiz({ body: { answer: answer, subEventId: subEventId } });
     }

--- a/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
+++ b/strawberry/src/pages/quizPlay/components/quizInput/CardInput.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { useGlobalState } from "../../../../core/hooks/useGlobalState";
+
 import { useQuizPlayState } from "../../hooks/useQuizPlayState";
 import { useQuizPlayDispatch } from "../../hooks/useQuizPlayDispatch";
 

--- a/strawberry/src/pages/quizPlay/hooks/logics/useQuizPlayPage.tsx
+++ b/strawberry/src/pages/quizPlay/hooks/logics/useQuizPlayPage.tsx
@@ -6,9 +6,12 @@ import { useQuizPlayMutation } from "../../../../data/queries/quiz/useQuizPlayMu
 
 import { useQuizPlayState } from "../useQuizPlayState";
 
+import usePrizeModal from "../usePrizeModal";
+
 function useQuizPlayPage() {
   const { mutate: postQuiz, isLoading } = useQuizPlayMutation();
   const globalDispatch = useGlobalDispatch();
+  const prizeModal = usePrizeModal();
 
   useEffect(() => {
     let timeoutId: number | undefined;
@@ -27,6 +30,17 @@ function useQuizPlayPage() {
 
     return () => clearTimeout(timeoutId);
   }, [isLoading, globalDispatch]);
+
+  const showBlankModal = () =>
+    globalDispatch?.({
+      type: "OPEN_MODAL",
+      modalCategory: "ONE_BUTTON",
+      modalProps: {
+        title: "공백만 제출할 수 없습니다.",
+        info: "올바른 답안을 제출해주세요.",
+        primaryBtnContent: "닫기",
+      },
+    });
 
   const {
     description,
@@ -47,6 +61,7 @@ function useQuizPlayPage() {
     answer,
     subEventId,
     postQuiz,
+    showBlankModal,
   };
 }
 

--- a/strawberry/src/pages/quizPlay/hooks/logics/useQuizPlayPage.tsx
+++ b/strawberry/src/pages/quizPlay/hooks/logics/useQuizPlayPage.tsx
@@ -6,12 +6,9 @@ import { useQuizPlayMutation } from "../../../../data/queries/quiz/useQuizPlayMu
 
 import { useQuizPlayState } from "../useQuizPlayState";
 
-import usePrizeModal from "../usePrizeModal";
-
 function useQuizPlayPage() {
   const { mutate: postQuiz, isLoading } = useQuizPlayMutation();
   const globalDispatch = useGlobalDispatch();
-  const prizeModal = usePrizeModal();
 
   useEffect(() => {
     let timeoutId: number | undefined;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#259-input-only-blank

### 💡 작업동기
- 문자열을 제출하는 post 요청에서 blank error를 방지하기 위해 코드 추가

### 🔑 주요 변경사항
- QuizPlay에서 blank만 제출 불가
- Expectation에서 blank만 제출 불가
- QuizPlay에서 blank만 제출 시 모달

### 🏞 스크린샷
![image](https://github.com/user-attachments/assets/79044cad-435a-4a3c-9ac5-ecfffcf45757)

### 관련 이슈
- closed: #259 
