### PR TITLE
퀴즈 랜딩 페이지에서 타이머에 따른 버튼 활성화 로직을 추가합니다.

### DIFF
--- a/strawberry/src/core/utils/convertSeconds.tsx
+++ b/strawberry/src/core/utils/convertSeconds.tsx
@@ -17,6 +17,7 @@ function convertSeconds(totalSeconds: number) {
     hours,
     minutes,
     seconds,
+    totalSeconds,
   };
 }
 

--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
@@ -5,9 +5,11 @@ import { Wrapper, EventButton } from "../../../../core/design_system";
 import { useQuizBanner } from "../../hooks";
 
 import QuizBannerTimer from "./QuizBannerTimer";
+import { useState } from "react";
 
 function QuizBanner() {
   const { data, handleEventClick } = useQuizBanner();
+  const [isOpened, setIsOpened] = useState<boolean>(false);
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">
@@ -21,14 +23,16 @@ function QuizBanner() {
         >
           <EventButton
             type="QUIZ"
-            status={data?.valid ? "DEFAULT" : "EVENT_END"}
+            status={
+              !data?.valid ? "EVENT_END" : isOpened ? "DEFAULT" : "DISABLED"
+            }
             content={
               data?.valid ? "이벤트 참여하기" : "이벤트가 종료되었습니다."
             }
             onClick={handleEventClick}
           ></EventButton>
         </Wrapper>
-        <QuizBannerTimer></QuizBannerTimer>
+        <QuizBannerTimer setIsOpened={setIsOpened} />
       </Wrapper>
     </Wrapper>
   );

--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBanner.tsx
@@ -5,11 +5,9 @@ import { Wrapper, EventButton } from "../../../../core/design_system";
 import { useQuizBanner } from "../../hooks";
 
 import QuizBannerTimer from "./QuizBannerTimer";
-import { useState } from "react";
 
 function QuizBanner() {
-  const { data, handleEventClick } = useQuizBanner();
-  const [isOpened, setIsOpened] = useState<boolean>(false);
+  const { data, handleEventClick, isOpened, setIsOpened } = useQuizBanner();
 
   return (
     <Wrapper $position="relative" height="calc(100vh - 70px)">

--- a/strawberry/src/pages/quizLanding/components/quizBanner/QuizBannerTimer.tsx
+++ b/strawberry/src/pages/quizLanding/components/quizBanner/QuizBannerTimer.tsx
@@ -5,12 +5,25 @@ import { theme, Wrapper } from "../../../../core/design_system";
 import { useTimeConversion, useQuizLandingState } from "../../hooks";
 
 import TimerSection from "./TimerSection";
+import { useEffect } from "react";
 
-function QuizBannerTimer() {
+interface QuizBannerTimerProps {
+  setIsOpened: (bool: boolean) => void;
+}
+
+function QuizBannerTimer({ setIsOpened }: QuizBannerTimerProps) {
   const { quizLandingData } = useQuizLandingState();
   const remainSecond = quizLandingData?.remainSecond;
 
   const time = useTimeConversion(remainSecond || 0);
+
+  useEffect(() => {
+    if (time.totalSeconds === 0) {
+      setIsOpened(true);
+    } else {
+      setIsOpened(false);
+    }
+  }, [time.totalSeconds]);
 
   return (
     <Wrapper

--- a/strawberry/src/pages/quizLanding/hooks/useQuizBanner.tsx
+++ b/strawberry/src/pages/quizLanding/hooks/useQuizBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useCheckLogin } from "../../../core/hooks/useCheckLogin";
@@ -11,6 +11,7 @@ export const useQuizBanner = () => {
   const checkLogin = useCheckLogin();
   const dispatch = useGlobalDispatch();
   const { quizLandingData: data } = useQuizLandingState();
+  const [isOpened, setIsOpened] = useState<boolean>(false);
 
   const handleEventClick = () => {
     checkLogin(() => {
@@ -36,5 +37,7 @@ export const useQuizBanner = () => {
   return {
     data,
     handleEventClick,
+    isOpened,
+    setIsOpened,
   };
 };

--- a/strawberry/src/pages/quizLanding/models/Timer.tsx
+++ b/strawberry/src/pages/quizLanding/models/Timer.tsx
@@ -3,4 +3,5 @@ export interface Timer {
   hours: number;
   minutes: number;
   seconds: number;
+  totalSeconds: number;
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#265-quiz-timer-button

### 💡 작업동기
- 선착순 퀴즈 이벤트의 버튼 로직을 추가합니다.

### 🔑 주요 변경사항
- Timer에 totalSeconds 추가
- isOpened를 사용하여 버튼 활성화 로직 추가

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d881ef3c-7ecf-4f8d-9f21-9f4a336c1fe8">

### 관련 이슈
- close: #265 
