### PR TITLE
퀴즈 플레이 화면에서 헤더 퀴즈 탭으로 이동 시의 문제를 해결합니다. 

### DIFF
--- a/strawberry/src/layout/components/header/HeaderMenuButtons.tsx
+++ b/strawberry/src/layout/components/header/HeaderMenuButtons.tsx
@@ -2,8 +2,6 @@ import DefaultButton from "../../../core/design_system/styles/DefaultButton";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 
-// 하단 요소 버튼에 리액트 라우터 적용 후 Link 태그 추가
-
 function HeaderMenuButtons() {
   return (
     <Ul>
@@ -18,9 +16,9 @@ function HeaderMenuButtons() {
         </Link>
       </li>
       <li>
-        <Link to="/quiz">
+        <button onClick={() => (location.href = "/quiz")}>
           <MenuButton>초성 퀴즈 이벤트</MenuButton>
-        </Link>
+        </button>
       </li>
       <li>
         <Link to="/drawing">


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix-#278-header-quiz

### 💡 작업동기
- 퀴즈 플레이 화면에서 헤더 퀴즈 탭으로 이동 시의 문제를 해결 

### 🔑 주요 변경사항
- Link 태그 href로 변경

### 관련 이슈
- closed: #278 
