### PR TITLE
기대평 페이지에 작성된 글이 없을 시에 보여줄 컴포넌트를 추가합니다.

### DIFF
--- a/strawberry/src/pages/expectation/ExpectationPage.tsx
+++ b/strawberry/src/pages/expectation/ExpectationPage.tsx
@@ -15,9 +15,14 @@ import {
 } from "./components";
 
 function ExpectationPage() {
-  const { expectationList, nowPage, totalPage, changePage, bannerImg } =
-    useExpectationPage();
-
+  const {
+    expectationList,
+    nowPage,
+    totalPage,
+    changePage,
+    bannerImg,
+    listError,
+  } = useExpectationPage();
   return (
     <>
       <ExpectationWrapper>
@@ -48,16 +53,24 @@ function ExpectationPage() {
             $alignitems="center"
             $minheight="1276px"
           >
-            {expectationList?.map(({ name, comment }, idx) => (
-              <ExpectationList key={idx} name={name} comment={comment} />
-            ))}
-            <Wrapper $margin="0 0 80px 0">
-              <Pagination
-                totalPages={totalPage}
-                currentPage={nowPage}
-                onPageChange={(page) => changePage(page)}
-              />
-            </Wrapper>
+            {listError?.status === 404 ? (
+              <NoExpectationWrapper>
+                첫 기대평을 작성해주세요!
+              </NoExpectationWrapper>
+            ) : (
+              <>
+                {expectationList?.map(({ name, comment }, idx) => (
+                  <ExpectationList key={idx} name={name} comment={comment} />
+                ))}
+                <Wrapper $margin="0 0 80px 0">
+                  <Pagination
+                    totalPages={totalPage}
+                    currentPage={nowPage}
+                    onPageChange={(page) => changePage(page)}
+                  />
+                </Wrapper>
+              </>
+            )}
           </Wrapper>
         </ExpectationContentWrapper>
         <EventNotice title="기대평 유의사항" notices={notices} />
@@ -67,6 +80,19 @@ function ExpectationPage() {
 }
 
 export default ExpectationPage;
+
+const NoExpectationWrapper = styled.div`
+  width: 100%;
+  max-width: 960px;
+  height: 250px;
+  border-radius: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  ${({ theme }) => theme.Typography.Display2Medium};
+  color: ${({ theme }) => theme.Color.TextIcon.info};
+`;
 
 const ExpectationWrapper = styled.div`
   position: relative;

--- a/strawberry/src/pages/expectation/hooks/logics/useExpectationPage.tsx
+++ b/strawberry/src/pages/expectation/hooks/logics/useExpectationPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { throttle } from "../../../../core/utils";
 
@@ -6,6 +6,7 @@ import useExpectationData from "../useExpectationData";
 import { useExpectationState } from "../useExpectationState";
 import { useExpectationDispatch } from "../useExpectationDispatch";
 import { ExpectationType } from "../../contexts/expectationContext";
+import { CustomError } from "../../../../data/config/customError";
 
 interface UseExpectationPageType {
   expectationList: ExpectationType[];
@@ -13,10 +14,11 @@ interface UseExpectationPageType {
   totalPage: number;
   changePage: () => void;
   bannerImg: string;
+  listError: CustomError | null;
 }
 
 function useExpectationPage(): UseExpectationPageType {
-  const { refetchList } = useExpectationData();
+  const { refetchList, listError } = useExpectationData();
   const { expectationList, nowPage, totalPage, bannerImg } =
     useExpectationState();
   const dispatch = useExpectationDispatch();
@@ -26,15 +28,21 @@ function useExpectationPage(): UseExpectationPageType {
   }, [nowPage, refetchList]);
 
   const changePage = throttle()((page: number) => {
+    console.log("click");
     dispatch({ type: "SET_NOW_PAGE", payload: page });
   });
+
+  const throttledChangePage = useMemo(() => {
+    return throttle()(changePage);
+  }, []);
 
   return {
     expectationList,
     nowPage,
     totalPage,
-    changePage,
+    changePage: throttledChangePage,
     bannerImg,
+    listError,
   };
 }
 

--- a/strawberry/src/pages/expectation/hooks/useExpectationData.tsx
+++ b/strawberry/src/pages/expectation/hooks/useExpectationData.tsx
@@ -9,9 +9,11 @@ import { useExpectationState } from "./useExpectationState";
 function useExpectationData() {
   const state = useExpectationState();
   const { data: pageData } = useExpectationPageQuery();
-  const { data: listData, refetch: refetchList } = useExpectationListQuery(
-    state.nowPage,
-  );
+  const {
+    data: listData,
+    refetch: refetchList,
+    error: listError,
+  } = useExpectationListQuery(state.nowPage);
   const dispatch = useExpectationDispatch();
 
   useEffect(() => {
@@ -36,7 +38,7 @@ function useExpectationData() {
     }
   }, [listData, dispatch]);
 
-  return { refetchList };
+  return { refetchList, listError };
 }
 
 export default useExpectationData;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat-#84-no-expectations

### 💡 작업동기
- 기대평이 없을 경우 404 에러를 처리하고 이에 맞는 컴포넌트를 렌더링

### 🔑 주요 변경사항
- 에러 핸들링 코드 추가
- 작성된 기대평이 없다는 컴포넌트 렌더링 코드 추가

### 🏞 스크린샷
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2acf80c5-d94f-4fb1-9bcc-a571f60b5e37">


### 관련 이슈
- closed: #84 
