### PR TITLE
feat: Lazy Loading, IntersectionObserver를 추가합니다.

### DIFF
--- a/strawberry/src/core/design_system/styles/Wrapper.tsx
+++ b/strawberry/src/core/design_system/styles/Wrapper.tsx
@@ -35,9 +35,16 @@ interface WrapperProps extends WrapperStyleProps {
   children: React.ReactNode;
 }
 
-function Wrapper({ children, ...props }: WrapperProps) {
-  return <StyledWrapper {...props}>{children}</StyledWrapper>;
-}
+// forwardRef를 사용하여 ref를 전달받을 수 있도록 수정
+const Wrapper = React.forwardRef<HTMLDivElement, WrapperProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <StyledWrapper ref={ref} {...props}>
+        {children}
+      </StyledWrapper>
+    );
+  },
+);
 
 export default Wrapper;
 
@@ -46,7 +53,7 @@ const StyledWrapper = styled.div<WrapperStyleProps>`
   ${({ $maxwidth }) => $maxwidth && `max-width: ${$maxwidth}`};
   height: ${({ height }) => height || "100%"};
   ${({ $minheight }) => $minheight && `min-height: ${$minheight}`};
-  ${({ $maxheight }) => $maxheight && `max-height: ${$maxheight}`}
+  ${({ $maxheight }) => $maxheight && `max-height: ${$maxheight}`};
 
   ${({ $position }) => $position && `position: ${$position}`};
 
@@ -55,13 +62,13 @@ const StyledWrapper = styled.div<WrapperStyleProps>`
 
   ${({ $backgroundcolor }) =>
     $backgroundcolor && `background-color: ${$backgroundcolor}`};
-  ${({ borderRadius }) => borderRadius && `border-radius: ${borderRadius}`}
+  ${({ borderRadius }) => borderRadius && `border-radius: ${borderRadius}`};
 
-  ${({ $bottom }) => $bottom && `bottom: ${$bottom};`};
-  ${({ left }) => left && `left: ${left};`};
-  ${({ right }) => right && `right: ${right};`};
-  ${({ $top }) => $top && `top: ${$top};`};
-  ${({ $zindex }) => $zindex && `z-index: ${$zindex};`};
+  ${({ $bottom }) => $bottom && `bottom: ${$bottom}`};
+  ${({ left }) => left && `left: ${left}`};
+  ${({ right }) => right && `right: ${right}`};
+  ${({ $top }) => $top && `top: ${$top}`};
+  ${({ $zindex }) => $zindex && `z-index: ${$zindex}`};
 
   ${({ display }) => display && `display: ${display}`};
   ${({ $flexdirection }) =>

--- a/strawberry/src/pages/newCar/NewCarPage.tsx
+++ b/strawberry/src/pages/newCar/NewCarPage.tsx
@@ -1,24 +1,147 @@
-import { Wrapper } from "../../core/design_system";
-import NewCarBanner from "./components/banner/NewCarBanner";
-import NewCarDesign from "./components/design/NewCarDesign";
-import NewCarParts from "./components/part/NewCarParts";
-import NewCarSpace from "./components/space/NewCarSpace";
-import NewCarDriving from "./components/driving/NewCarDriving";
-import NewCarGallery from "./components/gallery/NewCarGallery";
-import NewCarBottom from "./components/bottom/NewCarBottom";
+import React, { useRef, useEffect } from "react";
+import styled, { keyframes } from "styled-components";
+import RenderOnViewportEntry from "./RenderOnViewportEntry";
 
-function NewCarPage() {
+const NewCarPage: React.FC = () => {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "ArrowDown") {
+      scrollToNextSection();
+    } else if (event.key === "ArrowUp") {
+      scrollToPreviousSection();
+    }
+  };
+
+  const scrollToNextSection = () => {
+    if (scrollerRef.current) {
+      const currentScrollPosition = scrollerRef.current.scrollTop;
+      const sectionHeight = window.innerHeight;
+      const maxScroll = scrollerRef.current.scrollHeight - sectionHeight;
+
+      scrollerRef.current.scrollTo({
+        top: Math.min(currentScrollPosition + sectionHeight, maxScroll),
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const scrollToPreviousSection = () => {
+    if (scrollerRef.current) {
+      const currentScrollPosition = scrollerRef.current.scrollTop;
+      const sectionHeight = window.innerHeight;
+
+      scrollerRef.current.scrollTo({
+        top: Math.max(currentScrollPosition - sectionHeight, 0),
+        behavior: "smooth",
+      });
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
   return (
-    <Wrapper height="fit-content">
-      <NewCarBanner />
-      <NewCarParts />
-      <NewCarDesign />
-      <NewCarSpace />
-      <NewCarDriving />
-      <NewCarGallery />
-      <NewCarBottom />
-    </Wrapper>
+    <Scroller ref={scrollerRef}>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <NewCarBanner />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <NewCarParts />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DesignBanner />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DesignDetail designType="EXTERIOR" />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DesignCalligraphy designType="EXTERIOR" />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DesignDetail designType="INTERIOR" />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DesignCalligraphy designType="INTERIOR" />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <SpaceBanner />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <SpaceCarousel />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DrivingBanner />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <DrivingCarousel />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "100vh" }}>
+        <NewCarGallery />
+      </RenderOnViewportEntry>
+      <RenderOnViewportEntry style={{ minHeight: "200px" }}>
+        <NewCarBottom />
+      </RenderOnViewportEntry>
+    </Scroller>
   );
-}
+};
 
 export default NewCarPage;
+
+const NewCarBanner = React.lazy(
+  () => import("./components/banner/NewCarBanner"),
+);
+const NewCarParts = React.lazy(() => import("./components/part/NewCarParts"));
+const DesignBanner = React.lazy(
+  () => import("./components/design/DesignBanner"),
+);
+const DesignDetail = React.lazy(
+  () => import("./components/design/DesignDetail"),
+);
+const DesignCalligraphy = React.lazy(
+  () => import("./components/design/DesignCalligraphy"),
+);
+const SpaceBanner = React.lazy(() => import("./components/space/SpaceBanner"));
+const SpaceCarousel = React.lazy(
+  () => import("./components/space/SpaceCarousel"),
+);
+const DrivingBanner = React.lazy(
+  () => import("./components/driving/DrivingBanner"),
+);
+const DrivingCarousel = React.lazy(
+  () => import("./components/driving/DrivingCarousel"),
+);
+const NewCarGallery = React.lazy(
+  () => import("./components/gallery/NewCarGallery"),
+);
+const NewCarBottom = React.lazy(
+  () => import("./components/bottom/NewCarBottom"),
+);
+
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+// Scroller component with sections
+const Scroller = styled.div`
+  height: 100vh;
+  overflow-y: auto; /* Make sure it scrolls naturally */
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth; /* Ensure smooth scroll */
+
+  section {
+    scroll-snap-align: start;
+    animation: ${fadeIn} 0.8s ease-out both;
+  }
+`;

--- a/strawberry/src/pages/newCar/RenderOnViewportEntry.tsx
+++ b/strawberry/src/pages/newCar/RenderOnViewportEntry.tsx
@@ -1,0 +1,37 @@
+import React, { Suspense, useRef, ReactNode } from "react";
+import useFirstViewportEntry from "./useFirstViewportEntry";
+
+interface RenderOnViewportEntryProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  threshold?: number | number[];
+  root?: Element | null;
+  rootMargin?: string;
+}
+
+const RenderOnViewportEntry: React.FC<RenderOnViewportEntryProps> = ({
+  children,
+  threshold = 0,
+  root = null,
+  rootMargin = "0px 0px 0px 0px",
+  ...wrapperDivProps
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const entered = useFirstViewportEntry(ref, { threshold, root, rootMargin });
+
+  return (
+    <div {...wrapperDivProps} ref={ref}>
+      {entered && <Suspense fallback={<Loader />}>{children}</Suspense>}
+    </div>
+  );
+};
+
+export default RenderOnViewportEntry;
+
+const Loader: React.FC = () => {
+  return (
+    <div>
+      <p>Loading...</p>
+    </div>
+  );
+};

--- a/strawberry/src/pages/newCar/useFirstViewportEntry.ts
+++ b/strawberry/src/pages/newCar/useFirstViewportEntry.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState, MutableRefObject } from "react";
+
+interface ObserverOptions extends IntersectionObserverInit {}
+
+const useFirstViewportEntry = (
+  ref: MutableRefObject<Element | null>,
+  observerOptions: ObserverOptions,
+): boolean => {
+  const [entered, setEntered] = useState(false);
+
+  const observer = useRef<IntersectionObserver>(
+    new IntersectionObserver(
+      ([entry]) => setEntered(entry.isIntersecting),
+      observerOptions,
+    ),
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    const ob = observer.current;
+
+    if (entered) {
+      ob.disconnect();
+      return;
+    }
+
+    if (element && !entered) ob.observe(element);
+
+    return () => ob.disconnect();
+  }, [entered, ref]);
+
+  return entered;
+};
+
+export default useFirstViewportEntry;

--- a/strawberry/src/router/router.tsx
+++ b/strawberry/src/router/router.tsx
@@ -1,3 +1,4 @@
+import React, { Suspense } from "react";
 import { createBrowserRouter } from "react-router-dom";
 
 import PublicRoute from "./PublicRoute";
@@ -6,19 +7,36 @@ import ProtectedRoute from "./ProtectedRoute";
 import DefaultLayout from "../layout/DefaultLayout";
 import HeaderLayout from "../layout/HeaderLayout";
 
-import QuizPlayWrapper from "../pages/quizPlay/QuizPlayWrapper";
-import ExpectationPageWrapper from "../pages/expectation/ExpectationPageWrapper";
-import QuizLandingWrapper from "../pages/quizLanding/QuizLandingWrapper";
-import DrawingLandingWrapper from "../pages/drawingLanding/DrawingLandingWrapper";
-import DrawingPlayWrapper from "../pages/drawingPlay/DrawingPlayWrapper";
-import SharedRedirectedPage from "../pages/shared/SharedRedirectedPage";
+// Dynamically import pages
+const QuizPlayWrapper = React.lazy(
+  () => import("../pages/quizPlay/QuizPlayWrapper"),
+);
+const ExpectationPageWrapper = React.lazy(
+  () => import("../pages/expectation/ExpectationPageWrapper"),
+);
+const QuizLandingWrapper = React.lazy(
+  () => import("../pages/quizLanding/QuizLandingWrapper"),
+);
+const DrawingLandingWrapper = React.lazy(
+  () => import("../pages/drawingLanding/DrawingLandingWrapper"),
+);
+const DrawingPlayWrapper = React.lazy(
+  () => import("../pages/drawingPlay/DrawingPlayWrapper"),
+);
+const SharedRedirectedPage = React.lazy(
+  () => import("../pages/shared/SharedRedirectedPage"),
+);
+const LandingPage = React.lazy(() => import("../pages/landing/LandingPage"));
+const LoginPage = React.lazy(() => import("../pages/login/LoginPage"));
+const LoginRedirectedPage = React.lazy(
+  () => import("../pages/login/LoginRedirectPage"),
+);
+const NewCarPageWrapper = React.lazy(
+  () => import("../pages/newCar/NewCarPageWrapper"),
+);
+const NotFound = React.lazy(() => import("../pages/error/NotFound"));
 
-import LandingPage from "../pages/landing/LandingPage";
-import LoginPage from "../pages/login/LoginPage";
-import LoginRedirectedPage from "../pages/login/LoginRedirectPage";
-import NewCarPageWrapper from "../pages/newCar/components/NewCarPageWrapper";
-
-import NotFound from "../pages/error/NotFound";
+const Loading = () => <div>Loading...</div>;
 
 const router = createBrowserRouter([
   {
@@ -28,69 +46,79 @@ const router = createBrowserRouter([
       {
         path: "login",
         element: (
-          <PublicRoute>
-            <LoginPage />
-          </PublicRoute>
+          <Suspense fallback={<Loading />}>
+            <PublicRoute>
+              <LoginPage />
+            </PublicRoute>
+          </Suspense>
         ),
       },
       {
         path: "",
         element: (
-          <>
+          <Suspense fallback={<Loading />}>
             <LandingPage />
-          </>
+          </Suspense>
         ),
       },
       {
         path: "introduce",
         element: (
-          <>
+          <Suspense fallback={<Loading />}>
             <NewCarPageWrapper />
-          </>
+          </Suspense>
         ),
       },
       {
         path: "expectation",
         element: (
-          <>
+          <Suspense fallback={<Loading />}>
             <ExpectationPageWrapper />
-          </>
+          </Suspense>
         ),
       },
       {
         path: "quiz",
-        element: <QuizLandingWrapper />,
+        element: (
+          <Suspense fallback={<Loading />}>
+            <QuizLandingWrapper />
+          </Suspense>
+        ),
       },
       {
         path: "drawing",
-        element: <DrawingLandingWrapper />,
+        element: (
+          <Suspense fallback={<Loading />}>
+            <DrawingLandingWrapper />
+          </Suspense>
+        ),
       },
     ],
   },
   {
     path: "/",
     element: (
-      <>
+      <Suspense fallback={<Loading />}>
         <HeaderLayout>
           <ProtectedRoute />
         </HeaderLayout>
-      </>
+      </Suspense>
     ),
     children: [
       {
         path: "quiz/play/:subEventId/:token",
         element: (
-          <>
+          <Suspense fallback={<Loading />}>
             <QuizPlayWrapper />
-          </>
+          </Suspense>
         ),
       },
       {
         path: "drawing/play/:subEventId",
         element: (
-          <>
+          <Suspense fallback={<Loading />}>
             <DrawingPlayWrapper />
-          </>
+          </Suspense>
         ),
       },
     ],
@@ -98,21 +126,29 @@ const router = createBrowserRouter([
   {
     path: "auth/:sns/callback",
     element: (
-      <PublicRoute>
-        <LoginRedirectedPage />
-      </PublicRoute>
+      <Suspense fallback={<Loading />}>
+        <PublicRoute>
+          <LoginRedirectedPage />
+        </PublicRoute>
+      </Suspense>
     ),
   },
   {
     path: "shared/:sharedCode",
-    element: <SharedRedirectedPage />,
+    element: (
+      <Suspense fallback={<Loading />}>
+        <SharedRedirectedPage />
+      </Suspense>
+    ),
   },
   {
     path: "*",
     element: (
-      <HeaderLayout>
-        <NotFound />
-      </HeaderLayout>
+      <Suspense fallback={<Loading />}>
+        <HeaderLayout>
+          <NotFound />
+        </HeaderLayout>
+      </Suspense>
     ),
   },
 ]);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
feat/#293-lazy-loading

### 💡 작업동기
- 사용하지 않는 파일들까지 불러오는 현상을 해결하기 위해 Lazy loading을 추가합니다.
- Observer api를 추가하여, viewport에 들어올 때 로드하도록 변경합니다.
- 이미지에 lazy loading을 추가합니다 (다음 PR- 애니메이션에 같이 올리도록 하겠습니다.)

### 🔑 주요 변경사항
- 다른 탭에 있는 파일까지 불러오던 네트워크 파일 목록이 확연하게 줄었음을 확인할 수 있다.
- content Load 시간이 줄었음을 확인할 수 있다.
- 뿐만 아니라 스크롤 시에 파일들을 불러오는걸 확인할 수 있다.

### 🏞 스크린샷

[ Lazy Loading 적용 이후]
https://github.com/user-attachments/assets/4cd5781b-6d3b-4c49-8ca9-777b73c161cf

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b8c73697-146c-4158-ab5d-7b3b5f914ea3">


[ Lazy Loading 적용 이전 ]
https://github.com/user-attachments/assets/3e62d669-c360-4549-90b3-3779320b4715

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/db4f55d5-4906-48bd-b19e-e5b1baae8ccf">




### 관련 이슈
closed: #293 
